### PR TITLE
Fix test for 18.04

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,17 @@ jobs:
     container: ${{ matrix.image }}
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Setup environment
+        # Ubuntu 18.04 has a GLib version too old for nodejs20 or later,
+        # so, in order to do the tests, we must allow to use an older version.
+        # https://github.com/actions/checkout/issues/1590
+        # In that thread, Flamefire proposed this same solution:
+        # https://github.com/boostorg/nowide/commit/d4aa719f21149de8960247403435e9b794a01255
+        if: startsWith(matrix.image, 'ubuntu:18.04')
+        run: |
+          echo "GHA_USE_NODE_20=false" >> $GITHUB_ENV
+          echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
 
       - name: Initialise parameters
         id: params


### PR DESCRIPTION
The tests in Bionic fail due to a problem in nodejs. Found a workaround at the end of https://github.com/actions/checkout/issues/1590 It consists on disable using node20 and allow using an insecure version of nodejs.

Fix #168