### PR TITLE
Fix notices2 getters

### DIFF
--- a/snapd-glib/snapd-notice.c
+++ b/snapd-glib/snapd-notice.c
@@ -153,7 +153,7 @@ snapd_notice_get_last_data (SnapdNotice *self)
 }
 
 /**
- * snapd_notice_get_last_data2:
+ * snapd_notice_get_last_data2: (rename to snapd_notice_get_last_data)
  * @notice: a #SnapdNotice.
  *
  * Get the data of the notice.
@@ -190,7 +190,7 @@ snapd_notice_get_first_occurred (SnapdNotice *self)
 }
 
 /**
- * snapd_notice_get_first_occurred2:
+ * snapd_notice_get_first_occurred2: (rename to snapd_notice_get_first_occurred)
  * @notice: a #SnapdNotice.
  *
  * Get the time this notification first occurred.
@@ -229,7 +229,7 @@ snapd_notice_get_last_occurred (SnapdNotice *self)
 }
 
 /**
- * snapd_notice_get_last_occurred2:
+ * snapd_notice_get_last_occurred2: (rename to snapd_notice_get_last_occurred)
  * @notice: a #SnapdNotice.
  *
  * Get the time this notification last occurred.
@@ -289,7 +289,7 @@ snapd_notice_get_last_repeated (SnapdNotice *self)
 }
 
 /**
- * snapd_notice_get_last_repeated2:
+ * snapd_notice_get_last_repeated2: (rename to snapd_notice_get_last_repeated)
  * @notice: a #SnapdNotice.
  *
  * Get the time this notification last repeated.

--- a/snapd-glib/snapd-notice.c
+++ b/snapd-glib/snapd-notice.c
@@ -143,12 +143,30 @@ snapd_notice_get_key (SnapdNotice *self)
  * Returns: (transfer container): a HashTable with the data elements.
  *
  * Since: 1.65
+ * Deprecated: 1.66
  */
 GHashTable *
 snapd_notice_get_last_data (SnapdNotice *self)
 {
     g_return_val_if_fail (SNAPD_IS_NOTICE (self), NULL);
     return g_hash_table_ref (self->data);
+}
+
+/**
+ * snapd_notice_get_last_data2:
+ * @notice: a #SnapdNotice.
+ *
+ * Get the data of the notice.
+ *
+ * Returns: (transfer none): a HashTable with the data elements.
+ *
+ * Since: 1.66
+ */
+GHashTable *
+snapd_notice_get_last_data2 (SnapdNotice *self)
+{
+    g_return_val_if_fail (SNAPD_IS_NOTICE (self), NULL);
+    return self->data;
 }
 
 /**
@@ -160,6 +178,7 @@ snapd_notice_get_last_data (SnapdNotice *self)
  * Returns: (transfer full): a #GDateTime.
  *
  * Since: 1.65
+ * Deprecated: 1.66
  */
 GDateTime *
 snapd_notice_get_first_occurred (SnapdNotice *self)
@@ -171,6 +190,25 @@ snapd_notice_get_first_occurred (SnapdNotice *self)
 }
 
 /**
+ * snapd_notice_get_first_occurred2:
+ * @notice: a #SnapdNotice.
+ *
+ * Get the time this notification first occurred.
+ *
+ * Returns: (transfer none): a #GDateTime.
+ *
+ * Since: 1.66
+ */
+GDateTime *
+snapd_notice_get_first_occurred2 (SnapdNotice *self)
+{
+    g_return_val_if_fail (SNAPD_IS_NOTICE (self), NULL);
+    if (self->first_occurred == NULL)
+        return NULL;
+    return self->first_occurred;
+}
+
+/**
  * snapd_notice_get_last_occurred:
  * @notice: a #SnapdNotice.
  *
@@ -179,6 +217,7 @@ snapd_notice_get_first_occurred (SnapdNotice *self)
  * Returns: (transfer full): a #GDateTime.
  *
  * Since: 1.65
+ * Deprecated: 1.66
  */
 GDateTime *
 snapd_notice_get_last_occurred (SnapdNotice *self)
@@ -187,6 +226,25 @@ snapd_notice_get_last_occurred (SnapdNotice *self)
     if (self->last_occurred == NULL)
         return NULL;
     return g_date_time_ref (self->last_occurred);
+}
+
+/**
+ * snapd_notice_get_last_occurred2:
+ * @notice: a #SnapdNotice.
+ *
+ * Get the time this notification last occurred.
+ *
+ * Returns: (transfer none): a #GDateTime.
+ *
+ * Since: 1.66
+ */
+GDateTime *
+snapd_notice_get_last_occurred2 (SnapdNotice *self)
+{
+    g_return_val_if_fail (SNAPD_IS_NOTICE (self), NULL);
+    if (self->last_occurred == NULL)
+        return NULL;
+    return self->last_occurred;
 }
 
 /**
@@ -219,6 +277,7 @@ snapd_notice_get_last_occurred_nanoseconds (SnapdNotice *self)
  * Returns: (transfer full): a #GDateTime.
  *
  * Since: 1.65
+ * Deprecated: 1.66
  */
 GDateTime *
 snapd_notice_get_last_repeated (SnapdNotice *self)
@@ -227,6 +286,25 @@ snapd_notice_get_last_repeated (SnapdNotice *self)
     if (self->last_repeated == NULL)
         return NULL;
     return g_date_time_ref (self->last_repeated);
+}
+
+/**
+ * snapd_notice_get_last_repeated2:
+ * @notice: a #SnapdNotice.
+ *
+ * Get the time this notification last repeated.
+ *
+ * Returns: (transfer none): a #GDateTime.
+ *
+ * Since: 1.66
+ */
+GDateTime *
+snapd_notice_get_last_repeated2 (SnapdNotice *self)
+{
+    g_return_val_if_fail (SNAPD_IS_NOTICE (self), NULL);
+    if (self->last_repeated == NULL)
+        return NULL;
+    return self->last_repeated;
 }
 
 /**

--- a/snapd-glib/snapd-notice.c
+++ b/snapd-glib/snapd-notice.c
@@ -143,7 +143,7 @@ snapd_notice_get_key (SnapdNotice *self)
  * Returns: (transfer container): a HashTable with the data elements.
  *
  * Since: 1.65
- * Deprecated: 1.66
+ * Deprecated: 1.66: Use snapd_notice_get_last_data2()
  */
 GHashTable *
 snapd_notice_get_last_data (SnapdNotice *self)
@@ -178,7 +178,7 @@ snapd_notice_get_last_data2 (SnapdNotice *self)
  * Returns: (transfer full): a #GDateTime.
  *
  * Since: 1.65
- * Deprecated: 1.66
+ * Deprecated: 1.66: Use snapd_notice_get_first_occurred2()
  */
 GDateTime *
 snapd_notice_get_first_occurred (SnapdNotice *self)
@@ -203,8 +203,6 @@ GDateTime *
 snapd_notice_get_first_occurred2 (SnapdNotice *self)
 {
     g_return_val_if_fail (SNAPD_IS_NOTICE (self), NULL);
-    if (self->first_occurred == NULL)
-        return NULL;
     return self->first_occurred;
 }
 
@@ -217,7 +215,7 @@ snapd_notice_get_first_occurred2 (SnapdNotice *self)
  * Returns: (transfer full): a #GDateTime.
  *
  * Since: 1.65
- * Deprecated: 1.66
+ * Deprecated: 1.66: Use snapd_notice_get_last_occurred2()
  */
 GDateTime *
 snapd_notice_get_last_occurred (SnapdNotice *self)
@@ -242,8 +240,6 @@ GDateTime *
 snapd_notice_get_last_occurred2 (SnapdNotice *self)
 {
     g_return_val_if_fail (SNAPD_IS_NOTICE (self), NULL);
-    if (self->last_occurred == NULL)
-        return NULL;
     return self->last_occurred;
 }
 
@@ -277,7 +273,7 @@ snapd_notice_get_last_occurred_nanoseconds (SnapdNotice *self)
  * Returns: (transfer full): a #GDateTime.
  *
  * Since: 1.65
- * Deprecated: 1.66
+ * Deprecated: 1.66: Use snapd_notice_get_last_repeated2()
  */
 GDateTime *
 snapd_notice_get_last_repeated (SnapdNotice *self)
@@ -302,8 +298,6 @@ GDateTime *
 snapd_notice_get_last_repeated2 (SnapdNotice *self)
 {
     g_return_val_if_fail (SNAPD_IS_NOTICE (self), NULL);
-    if (self->last_repeated == NULL)
-        return NULL;
     return self->last_repeated;
 }
 

--- a/snapd-glib/snapd-notice.h
+++ b/snapd-glib/snapd-notice.h
@@ -40,15 +40,23 @@ const gchar           *snapd_notice_get_key            (SnapdNotice *notice);
 
 GDateTime             *snapd_notice_get_first_occurred (SnapdNotice *notice);
 
+GDateTime             *snapd_notice_get_first_occurred2 (SnapdNotice *notice);
+
 GDateTime             *snapd_notice_get_last_occurred  (SnapdNotice *notice);
+
+GDateTime             *snapd_notice_get_last_occurred2 (SnapdNotice *notice);
 
 int                    snapd_notice_get_last_occurred_nanoseconds (SnapdNotice *notice);
 
 GDateTime             *snapd_notice_get_last_repeated  (SnapdNotice *notice);
 
+GDateTime             *snapd_notice_get_last_repeated2 (SnapdNotice *notice);
+
 gint64                 snapd_notice_get_occurrences    (SnapdNotice *notice);
 
 GHashTable            *snapd_notice_get_last_data      (SnapdNotice *notice);
+
+GHashTable            *snapd_notice_get_last_data2     (SnapdNotice *notice);
 
 GTimeSpan              snapd_notice_get_repeat_after   (SnapdNotice *notice);
 

--- a/snapd-glib/snapd-notices-monitor.c
+++ b/snapd-glib/snapd-notices-monitor.c
@@ -74,7 +74,7 @@ static void
 begin_monitor (SnapdNoticesMonitor *self)
 {
     snapd_client_notices_set_after_notice (self->client, self->last_notice);
-    g_autoptr(GDateTime) last_date_time = self->last_notice == NULL ? NULL : (GDateTime *) snapd_notice_get_last_occurred (self->last_notice);
+    GDateTime *last_date_time = self->last_notice == NULL ? NULL : (GDateTime *) snapd_notice_get_last_occurred (self->last_notice);
     snapd_client_get_notices_async(self->client,
                                    last_date_time,
                                    2000000000000000, // "infinity" (there is a limit in snapd, around 9 billion seconds)

--- a/snapd-qt/notice.cpp
+++ b/snapd-qt/notice.cpp
@@ -60,17 +60,17 @@ static QDateTime convertDateTime (GDateTime *datetime)
 
 QDateTime QSnapdNotice::firstOccurred () const
 {
-    return convertDateTime ((GDateTime*) snapd_notice_get_first_occurred (SNAPD_NOTICE (wrapped_object)));
+    return convertDateTime ((GDateTime*) snapd_notice_get_first_occurred2 (SNAPD_NOTICE (wrapped_object)));
 }
 
 QDateTime QSnapdNotice::lastOccurred () const
 {
-    return convertDateTime ((GDateTime*) snapd_notice_get_last_occurred (SNAPD_NOTICE (wrapped_object)));
+    return convertDateTime ((GDateTime*) snapd_notice_get_last_occurred2 (SNAPD_NOTICE (wrapped_object)));
 }
 
 QDateTime QSnapdNotice::lastRepeated () const
 {
-    return convertDateTime ((GDateTime*) snapd_notice_get_last_repeated (SNAPD_NOTICE (wrapped_object)));
+    return convertDateTime ((GDateTime*) snapd_notice_get_last_repeated2 (SNAPD_NOTICE (wrapped_object)));
 }
 
 qint32 QSnapdNotice::occurrences () const
@@ -102,7 +102,7 @@ addItemToQHash (gchar *key, gchar *value, QHash<QString, QString> *lastData)
 QHash<QString, QString> QSnapdNotice::lastData () const
 {
     QHash<QString, QString> lastData;
-    g_autoptr(GHashTable) last_data = snapd_notice_get_last_data (SNAPD_NOTICE (wrapped_object));
+    GHashTable *last_data = snapd_notice_get_last_data2 (SNAPD_NOTICE (wrapped_object));
     g_hash_table_foreach (last_data, (GHFunc) addItemToQHash, &lastData);
     return lastData;
 }

--- a/snapd-qt/notice.cpp
+++ b/snapd-qt/notice.cpp
@@ -60,17 +60,17 @@ static QDateTime convertDateTime (GDateTime *datetime)
 
 QDateTime QSnapdNotice::firstOccurred () const
 {
-    return convertDateTime ((GDateTime*) snapd_notice_get_first_occurred2 (SNAPD_NOTICE (wrapped_object)));
+    return convertDateTime (snapd_notice_get_first_occurred2 (SNAPD_NOTICE (wrapped_object)));
 }
 
 QDateTime QSnapdNotice::lastOccurred () const
 {
-    return convertDateTime ((GDateTime*) snapd_notice_get_last_occurred2 (SNAPD_NOTICE (wrapped_object)));
+    return convertDateTime (snapd_notice_get_last_occurred2 (SNAPD_NOTICE (wrapped_object)));
 }
 
 QDateTime QSnapdNotice::lastRepeated () const
 {
-    return convertDateTime ((GDateTime*) snapd_notice_get_last_repeated2 (SNAPD_NOTICE (wrapped_object)));
+    return convertDateTime (snapd_notice_get_last_repeated2 (SNAPD_NOTICE (wrapped_object)));
 }
 
 qint32 QSnapdNotice::occurrences () const

--- a/tests/test-glib.c
+++ b/tests/test-glib.c
@@ -8613,15 +8613,15 @@ test_notices_events_cb (GObject* object, GAsyncResult* result, gpointer user_dat
     g_autoptr(GDateTime) date2 = g_date_time_new (timezone, 2025, 4, 2, 23, 28, 8);
     g_autoptr(GDateTime) date3 = g_date_time_new (timezone, 2026, 5, 3, 22, 20, 7);
 
-    g_assert_true (g_date_time_equal (snapd_notice_get_first_occurred (notice1), date1));
-    g_assert_true (g_date_time_equal (snapd_notice_get_last_occurred (notice1), date2));
-    g_assert_true (g_date_time_equal (snapd_notice_get_last_repeated (notice1), date3));
+    g_assert_true (g_date_time_equal (snapd_notice_get_first_occurred2 (notice1), date1));
+    g_assert_true (g_date_time_equal (snapd_notice_get_last_occurred2 (notice1), date2));
+    g_assert_true (g_date_time_equal (snapd_notice_get_last_repeated2 (notice1), date3));
 
     g_assert_true (snapd_notice_get_notice_type (notice1) == SNAPD_NOTICE_TYPE_UNKNOWN);
 
     g_assert_cmpint (snapd_notice_get_occurrences(notice1), ==, 5);
 
-    g_autoptr(GHashTable) notice_data1 = snapd_notice_get_last_data (notice1);
+    GHashTable *notice_data1 = snapd_notice_get_last_data2 (notice1);
     g_assert_nonnull (notice_data1);
     g_assert_cmpint (g_hash_table_size (notice_data1), ==, 0);
 
@@ -8636,15 +8636,15 @@ test_notices_events_cb (GObject* object, GAsyncResult* result, gpointer user_dat
     g_autoptr(GDateTime) date4 = g_date_time_new (timezone2, 2023, 2, 5, 21, 23, 3);
     g_autoptr(GDateTime) date5 = g_date_time_new (timezone2, 2023, 2, 5, 21, 23, 3.000123);
 
-    g_assert_true (g_date_time_equal (snapd_notice_get_first_occurred (notice2), date4));
-    g_assert_true (g_date_time_equal (snapd_notice_get_last_occurred (notice2), date5));
-    g_assert_true (g_date_time_equal (snapd_notice_get_last_repeated (notice2), date4));
+    g_assert_true (g_date_time_equal (snapd_notice_get_first_occurred2 (notice2), date4));
+    g_assert_true (g_date_time_equal (snapd_notice_get_last_occurred2 (notice2), date5));
+    g_assert_true (g_date_time_equal (snapd_notice_get_last_repeated2 (notice2), date4));
 
     g_assert_cmpint (snapd_notice_get_occurrences(notice2), ==, 1);
 
     g_assert_true (snapd_notice_get_notice_type (notice2) == SNAPD_NOTICE_TYPE_REFRESH_INHIBIT);
 
-    g_autoptr(GHashTable) notice_data2 = snapd_notice_get_last_data (notice2);
+    GHashTable *notice_data2 = snapd_notice_get_last_data2 (notice2);
     g_assert_nonnull (notice_data2);
     g_assert_cmpint (g_hash_table_size (notice_data2), ==, 1);
     g_assert_true (g_hash_table_contains (notice_data2, "kind"));
@@ -8768,15 +8768,15 @@ test_notices_minimal_data_events_cb (GObject* object, GAsyncResult* result, gpoi
 
     g_assert_cmpint (snapd_notice_get_repeat_after(notice1), ==, 0);
 
-    g_assert_null (snapd_notice_get_first_occurred (notice1));
-    g_assert_null (snapd_notice_get_last_occurred (notice1));
-    g_assert_null (snapd_notice_get_last_repeated (notice1));
+    g_assert_null (snapd_notice_get_first_occurred2 (notice1));
+    g_assert_null (snapd_notice_get_last_occurred2 (notice1));
+    g_assert_null (snapd_notice_get_last_repeated2 (notice1));
 
     g_assert_true (snapd_notice_get_notice_type (notice1) == SNAPD_NOTICE_TYPE_UNKNOWN);
 
     g_assert_cmpint (snapd_notice_get_occurrences(notice1), ==, -1);
 
-    g_autoptr(GHashTable) notice_data = snapd_notice_get_last_data (notice1);
+    GHashTable *notice_data = snapd_notice_get_last_data2 (notice1);
     g_assert_nonnull (notice_data);
     g_assert_cmpint (g_hash_table_size (notice_data), ==, 0);
 


### PR DESCRIPTION
Several getters were returning a reference of the data instead of just a pointer; this is, they incremented the refcount of the returned element. This isn't what the rest of the API does, so for uniformity, this PR adds new versions of the getters and deprecates the old ones.
    
Fix #170