### PR TITLE
Fix build in ARMHF

### DIFF
--- a/snapd-glib/requests/snapd-get-notices.c
+++ b/snapd-glib/requests/snapd-get-notices.c
@@ -86,7 +86,7 @@ generate_get_snap_request (SnapdRequest *request, GBytes **body)
     if (self->timeout != 0) {
         add_uri_parameter_base (query, "timeout");
         // timeout in microseconds
-        g_string_append_printf (query, "%luus", self->timeout);
+        g_string_append_printf (query, "%lluus", (long long int)self->timeout);
     }
 
     if (query->len != 0)

--- a/snapd-glib/requests/snapd-get-notices.c
+++ b/snapd-glib/requests/snapd-get-notices.c
@@ -86,7 +86,7 @@ generate_get_snap_request (SnapdRequest *request, GBytes **body)
     if (self->timeout != 0) {
         add_uri_parameter_base (query, "timeout");
         // timeout in microseconds
-        g_string_append_printf (query, "%lluus", (long long int)self->timeout);
+        g_string_append_printf (query, "%lluus", (long long unsigned int)self->timeout);
     }
 
     if (query->len != 0)

--- a/snapd-glib/requests/snapd-json.c
+++ b/snapd-glib/requests/snapd-json.c
@@ -75,7 +75,7 @@ _snapd_json_get_int_as_string (JsonObject *object, const gchar *name)
     if (node == NULL)
         return NULL;
     if (json_node_get_value_type (node) == G_TYPE_INT64)
-        return g_strdup_printf("%ld", json_node_get_int (node));
+        return g_strdup_printf("%lld", json_node_get_int (node));
     else if (json_node_get_value_type (node) == G_TYPE_STRING)
         return g_strdup(json_node_get_string (node));
     return NULL;

--- a/snapd-glib/requests/snapd-json.c
+++ b/snapd-glib/requests/snapd-json.c
@@ -75,7 +75,7 @@ _snapd_json_get_int_as_string (JsonObject *object, const gchar *name)
     if (node == NULL)
         return NULL;
     if (json_node_get_value_type (node) == G_TYPE_INT64)
-        return g_strdup_printf("%lld", json_node_get_int (node));
+        return g_strdup_printf("%lld", (long long int)json_node_get_int (node));
     else if (json_node_get_value_type (node) == G_TYPE_STRING)
         return g_strdup(json_node_get_string (node));
     return NULL;


### PR DESCRIPTION
Since in 64bit architectures, long int is the same than long long int, using %ld or %lu is the same than %lld and %llu. But this isn't the case for 32bit architectures.