### PR TITLE
Fix build in 32bit systems

### DIFF
--- a/snapd-glib/requests/snapd-get-notices.c
+++ b/snapd-glib/requests/snapd-get-notices.c
@@ -102,8 +102,8 @@ generate_get_snap_request (SnapdRequest *request, GBytes **body)
     }
     if (self->timeout != 0) {
         add_uri_parameter_base (query, "timeout");
-        // timeout in microseconds
-        g_string_append_printf (query, "%lluus", (unsigned long long int)self->timeout);
+        // timeout in microseconds. self->timeout is a GTimeSpan, which is a typedef into a gint64 type
+        g_string_append_printf (query, "%" G_GINT64_FORMAT "us", self->timeout);
     }
 
     if (query->len != 0)

--- a/snapd-glib/requests/snapd-get-notices.c
+++ b/snapd-glib/requests/snapd-get-notices.c
@@ -103,7 +103,7 @@ generate_get_snap_request (SnapdRequest *request, GBytes **body)
     if (self->timeout != 0) {
         add_uri_parameter_base (query, "timeout");
         // timeout in microseconds
-        g_string_append_printf (query, "%luus", self->timeout);
+        g_string_append_printf (query, "%lluus", (unsigned long long int)self->timeout);
     }
 
     if (query->len != 0)

--- a/snapd-glib/requests/snapd-json.c
+++ b/snapd-glib/requests/snapd-json.c
@@ -678,7 +678,7 @@ get_int_as_string (JsonObject *object, const gchar *name)
     if (node == NULL)
         return NULL;
     if (json_node_get_value_type (node) == G_TYPE_INT64)
-        return g_strdup_printf("%lld", (long long int)json_node_get_int (node));
+        return g_strdup_printf("%" G_GINT64_FORMAT, json_node_get_int (node));
     else if (json_node_get_value_type (node) == G_TYPE_STRING)
         return g_strdup(json_node_get_string (node));
     return NULL;

--- a/snapd-glib/requests/snapd-json.c
+++ b/snapd-glib/requests/snapd-json.c
@@ -678,7 +678,7 @@ get_int_as_string (JsonObject *object, const gchar *name)
     if (node == NULL)
         return NULL;
     if (json_node_get_value_type (node) == G_TYPE_INT64)
-        return g_strdup_printf("%ld", json_node_get_int (node));
+        return g_strdup_printf("%lld", (long long int)json_node_get_int (node));
     else if (json_node_get_value_type (node) == G_TYPE_STRING)
         return g_strdup(json_node_get_string (node));
     return NULL;


### PR DESCRIPTION
At least in ARMhf systems, the current code fails due to the difference in sizes for long int and long long int. This patch fixes it.

Fix https://github.com/canonical/snapd-glib/issues/162