### PR TITLE
Generate documentation on push to master

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,0 +1,52 @@
+name: documentation
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:rolling
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Install dependencies (Ubuntu)
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends meson ninja-build gtk-doc-tools libgirepository1.0-dev libglib2.0-dev libjson-glib-dev ninja-build python3-pip python3-setuptools python3-wheel valac libsoup-3.0-dev qt6-base-dev qt6-declarative-dev
+      - name: Build documentation
+        run: |
+          meson setup _build -Ddocs=true
+          ninja -C _build snapd-glib-doc
+          mkdir -p ./_site
+          cp -v -a ./_build/doc/reference/html/* ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v3
+

--- a/doc/reference/meson.build
+++ b/doc/reference/meson.build
@@ -1,7 +1,7 @@
 subdir ('xml')
 
 if get_option ('docs')
-  glib_prefix = dependency ('glib-2.0').get_pkgconfig_variable ('prefix')
+  glib_prefix = dependency ('glib-2.0').get_variable (pkgconfig: 'prefix')
   glib_docpath = join_paths (glib_prefix, 'share', 'gtk-doc', 'html')
   docpath = join_paths (datadir, 'gtk-doc', 'html')
 
@@ -11,8 +11,8 @@ if get_option ('docs')
   gnome.gtkdoc ('snapd-glib',
                 main_xml: 'snapd-glib-docs.xml',
                 src_dir: [
-                  join_paths (meson.source_root (), 'snapd-glib'),
-                  join_paths (meson.build_root (), 'snapd-glib')
+                  join_paths (meson.project_source_root (), 'snapd-glib'),
+                  join_paths (meson.project_build_root (), 'snapd-glib')
                 ],
                 dependencies: snapd_glib_dep,
                 scan_args: [


### PR DESCRIPTION
It seems that gi-docgen is still experimental, so I decided to maintain gtk-doc and just create a workflow to generate the HTML and upload it to the pages of snapd-glib.