### PR TITLE
Fix GIR comments

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+ReflowComments: false

--- a/snapd-glib/snapd-client-sync.c
+++ b/snapd-glib/snapd-client-sync.c
@@ -663,10 +663,10 @@ GPtrArray *snapd_client_get_interfaces2_sync(SnapdClient *self,
 /**
  * snapd_client_get_connections_sync:
  * @client: a #SnapdClient.
- * @established: (out) (allow-none) (transfer container) (element-type
- * SnapdConnection): the location to store the array of connections or %NULL.
- * @undesired: (out) (allow-none) (transfer container) (element-type
- * SnapdConnection): the location to store the array of auto-connected
+ * @established: (out) (allow-none) (transfer container) (element-type SnapdConnection):
+ * the location to store the array of connections or %NULL.
+ * @undesired: (out) (allow-none) (transfer container) (element-type SnapdConnection):
+ * the location to store the array of auto-connected
  * connections that have been manually disconnected or %NULL.
  * @plugs: (out) (allow-none) (transfer container) (element-type SnapdPlug): the
  * location to store the array of #SnapdPlug or %NULL.
@@ -712,10 +712,10 @@ gboolean snapd_client_get_connections_sync(SnapdClient *self,
  * all snaps.
  * @interface: (allow-none): the name of the interface to get connections for or
  * %NULL for all interfaces.
- * @established: (out) (allow-none) (transfer container) (element-type
- * SnapdConnection): the location to store the array of connections or %NULL.
- * @undesired: (out) (allow-none) (transfer container) (element-type
- * SnapdConnection): the location to store the array of auto-connected
+ * @established: (out) (allow-none) (transfer container) (element-type SnapdConnection):
+ * the location to store the array of connections or %NULL.
+ * @undesired: (out) (allow-none) (transfer container) (element-type SnapdConnection):
+ * the location to store the array of auto-connected
  * connections that have been manually disconnected or %NULL.
  * @plugs: (out) (allow-none) (transfer container) (element-type SnapdPlug): the
  * location to store the array of #SnapdPlug or %NULL.
@@ -1857,12 +1857,12 @@ GBytes *snapd_client_download_sync(SnapdClient *self, const gchar *name,
  * @gtk_theme_names: (allow-none): a list of GTK theme names.
  * @icon_theme_names: (allow-none): a list of icon theme names.
  * @sound_theme_names: (allow-none): a list of sound theme names.
- * @gtk_theme_status: (out) (transfer container) (element-type utf8
- * SnapdThemeStatus): status of GTK themes.
- * @icon_theme_status: (out) (transfer container) (element-type utf8
- * SnapdThemeStatus): status of icon themes.
- * @sound_theme_status: (out) (transfer container) (element-type utf8
- * SnapdThemeStatus): status of sound themes.
+ * @gtk_theme_status: (out) (transfer container) (element-type utf8 SnapdThemeStatus):
+ * status of GTK themes.
+ * @icon_theme_status: (out) (transfer container) (element-type utf8 SnapdThemeStatus):
+ * status of icon themes.
+ * @sound_theme_status: (out) (transfer container) (element-type utf8 SnapdThemeStatus):
+ * status of sound themes.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL
  * to ignore.

--- a/snapd-glib/snapd-client.c
+++ b/snapd-glib/snapd-client.c
@@ -2457,10 +2457,10 @@ void snapd_client_get_connections_async(SnapdClient *self,
  * snapd_client_get_connections_finish:
  * @client: a #SnapdClient.
  * @result: a #GAsyncResult.
- * @established: (out) (allow-none) (transfer container) (element-type
- * SnapdConnection): the location to store the array of connections or %NULL.
- * @undesired: (out) (allow-none) (transfer container) (element-type
- * SnapdConnection): the location to store the array of auto-connected
+ * @established: (out) (allow-none) (transfer container) (element-type SnapdConnection):
+ * the location to store the array of connections or %NULL.
+ * @undesired: (out) (allow-none) (transfer container) (element-type SnapdConnection):
+ * the location to store the array of auto-connected
  * connections that have been manually disconnected or %NULL.
  * @plugs: (out) (allow-none) (transfer container) (element-type SnapdPlug): the
  * location to store the array of #SnapdPlug or %NULL.
@@ -2523,10 +2523,10 @@ void snapd_client_get_connections2_async(
  * snapd_client_get_connections2_finish:
  * @client: a #SnapdClient.
  * @result: a #GAsyncResult.
- * @established: (out) (allow-none) (transfer container) (element-type
- * SnapdConnection): the location to store the array of connections or %NULL.
- * @undesired: (out) (allow-none) (transfer container) (element-type
- * SnapdConnection): the location to store the array of auto-connected
+ * @established: (out) (allow-none) (transfer container) (element-type SnapdConnection):
+ * the location to store the array of connections or %NULL.
+ * @undesired: (out) (allow-none) (transfer container) (element-type SnapdConnection):
+ * the location to store the array of auto-connected
  * connections that have been manually disconnected or %NULL.
  * @plugs: (out) (allow-none) (transfer container) (element-type SnapdPlug): the
  * location to store the array of #SnapdPlug or %NULL.
@@ -4608,12 +4608,12 @@ void snapd_client_check_themes_async(SnapdClient *self, GStrv gtk_theme_names,
  * snapd_client_check_themes_finish:
  * @client: a #SnapdClient.
  * @result: a #GAsyncResult.
- * @gtk_theme_status: (out) (transfer container) (element-type utf8
- * SnapdThemeStatus): status of GTK themes.
- * @icon_theme_status: (out) (transfer container) (element-type utf8
- * SnapdThemeStatus): status of icon themes.
- * @sound_theme_status: (out) (transfer container) (element-type utf8
- * SnapdThemeStatus): status of sound themes.
+ * @gtk_theme_status: (out) (transfer container) (element-type utf8 SnapdThemeStatus):
+ * status of GTK themes.
+ * @icon_theme_status: (out) (transfer container) (element-type utf8 SnapdThemeStatus):
+ * status of icon themes.
+ * @sound_theme_status: (out) (transfer container) (element-type utf8 SnapdThemeStatus):
+ * status of sound themes.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL
  * to ignore.
  *


### PR DESCRIPTION
The autoformatting has the problem of cutting comments in several lines, which is a problem for the GIR parser if a GIR line with parentheses is cut and the opening and closing parentheses are in different lines.

This change instructs clang-format to not reflow comments. It also fixes the GIR errors.