### PR TITLE
Fix memory leaks in mock

### DIFF
--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -4948,7 +4948,7 @@ static void handle_notices(MockSnapd *self, SoupServerMessage *message,
     }
     guint data_size = g_hash_table_size(notice->last_data);
     if (data_size != 0) {
-      gchar **keys =
+      g_autofree gchar **keys =
           (gchar **)g_hash_table_get_keys_as_array(notice->last_data, NULL);
       json_builder_set_member_name(builder, "last-data");
       json_builder_begin_object(builder);
@@ -4958,7 +4958,6 @@ static void handle_notices(MockSnapd *self, SoupServerMessage *message,
         json_builder_add_string_value(builder, value);
       }
       json_builder_end_object(builder);
-      g_free(keys);
     }
     json_builder_end_object(builder);
   }

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -1692,8 +1692,8 @@ static void mock_change_free(MockChange *change) {
   g_clear_list(&change->tasks, (GDestroyNotify)mock_task_free);
 #else
   if (change->tasks) {
-    g_list_free_full(change->task, (GDestroyNotify)mock_task_free);
-    change->taks = NULL;
+    g_list_free_full(change->tasks, (GDestroyNotify)mock_task_free);
+    change->tasks = NULL;
   }
 #endif
   g_clear_pointer(&change->data, json_node_unref);

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -1679,7 +1679,7 @@ static void mock_task_free(MockTask *task) {
     mock_snap_free(task->snap);
   g_free(task->snap_name);
   g_free(task->error);
-  g_ptr_array_free(task->affected_snaps, TRUE);
+  g_ptr_array_unref(task->affected_snaps);
   g_slice_free(MockTask, task);
 }
 

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -1678,6 +1678,7 @@ static void mock_task_free(MockTask *task) {
     mock_snap_free(task->snap);
   g_free(task->snap_name);
   g_free(task->error);
+  g_ptr_array_free(task->affected_snaps, TRUE);
   g_slice_free(MockTask, task);
 }
 

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -1675,11 +1675,10 @@ static void mock_task_free(MockTask *task) {
   g_free(task->progress_label);
   g_free(task->spawn_time);
   g_free(task->ready_time);
-  if (task->snap != NULL)
-    mock_snap_free(task->snap);
+  g_clear_pointer(&task->snap, mock_snap_free);
   g_free(task->snap_name);
   g_free(task->error);
-  g_ptr_array_unref(task->affected_snaps);
+  g_clear_pointer(&task->affected_snaps, g_ptr_array_unref);
   g_slice_free(MockTask, task);
 }
 
@@ -1689,9 +1688,8 @@ static void mock_change_free(MockChange *change) {
   g_free(change->summary);
   g_free(change->spawn_time);
   g_free(change->ready_time);
-  g_list_free_full(change->tasks, (GDestroyNotify)mock_task_free);
-  if (change->data != NULL)
-    json_node_unref(change->data);
+  g_clear_list(&change->tasks, (GDestroyNotify)mock_task_free);
+  g_clear_pointer(&change->data, json_node_unref);
   g_slice_free(MockChange, change);
 }
 
@@ -5176,8 +5174,7 @@ static void mock_snapd_finalize(GObject *object) {
   g_clear_pointer(&self->sound_theme_status, g_hash_table_unref);
   g_clear_pointer(&self->context, g_main_context_unref);
   g_clear_pointer(&self->loop, g_main_loop_unref);
-  g_list_free_full(self->notices, (GDestroyNotify)mock_notice_free);
-  self->notices = NULL;
+  g_clear_list(&self->notices, (GDestroyNotify)mock_notice_free);
   g_clear_pointer(&self->notices_parameters, g_free);
 
   g_cond_clear(&self->condition);

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -404,6 +404,7 @@ static void mock_snap_free(MockSnap *snap) {
   g_free(snap->publisher_validation);
   g_free(snap->revision);
   g_free(snap->status);
+  g_free(snap->proceed_time);
   g_free(snap->store_url);
   g_free(snap->summary);
   g_free(snap->title);

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -5177,6 +5177,7 @@ static void mock_snapd_finalize(GObject *object) {
   g_clear_pointer(&self->loop, g_main_loop_unref);
   g_list_free_full(self->notices, (GDestroyNotify)mock_notice_free);
   self->notices = NULL;
+  g_clear_pointer(&self->notices_parameters, g_free);
 
   g_cond_clear(&self->condition);
   g_mutex_clear(&self->mutex);

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -4957,6 +4957,7 @@ static void handle_notices(MockSnapd *self, SoupServerMessage *message,
         json_builder_add_string_value(builder, value);
       }
       json_builder_end_object(builder);
+      g_free(keys);
     }
     json_builder_end_object(builder);
   }

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -1688,7 +1688,14 @@ static void mock_change_free(MockChange *change) {
   g_free(change->summary);
   g_free(change->spawn_time);
   g_free(change->ready_time);
+#ifdef GLIB_VERSION_2_64
   g_clear_list(&change->tasks, (GDestroyNotify)mock_task_free);
+#else
+  if (change->tasks) {
+    g_list_free_full(change->task, (GDestroyNotify)mock_task_free);
+    change->taks = NULL;
+  }
+#endif
   g_clear_pointer(&change->data, json_node_unref);
   g_slice_free(MockChange, change);
 }
@@ -5174,7 +5181,14 @@ static void mock_snapd_finalize(GObject *object) {
   g_clear_pointer(&self->sound_theme_status, g_hash_table_unref);
   g_clear_pointer(&self->context, g_main_context_unref);
   g_clear_pointer(&self->loop, g_main_loop_unref);
+#ifdef GLIB_VERSION_2_64
   g_clear_list(&self->notices, (GDestroyNotify)mock_notice_free);
+#else
+  if (self->notices) {
+    g_list_free_full(self->notices, (GDestroyNotify)mock_notice_free);
+    self->notices = NULL;
+  }
+#endif
   g_clear_pointer(&self->notices_parameters, g_free);
 
   g_cond_clear(&self->condition);

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -1688,14 +1688,10 @@ static void mock_change_free(MockChange *change) {
   g_free(change->summary);
   g_free(change->spawn_time);
   g_free(change->ready_time);
-#ifdef GLIB_VERSION_2_64
-  g_clear_list(&change->tasks, (GDestroyNotify)mock_task_free);
-#else
   if (change->tasks) {
     g_list_free_full(change->tasks, (GDestroyNotify)mock_task_free);
     change->tasks = NULL;
   }
-#endif
   g_clear_pointer(&change->data, json_node_unref);
   g_slice_free(MockChange, change);
 }
@@ -5181,14 +5177,10 @@ static void mock_snapd_finalize(GObject *object) {
   g_clear_pointer(&self->sound_theme_status, g_hash_table_unref);
   g_clear_pointer(&self->context, g_main_context_unref);
   g_clear_pointer(&self->loop, g_main_loop_unref);
-#ifdef GLIB_VERSION_2_64
-  g_clear_list(&self->notices, (GDestroyNotify)mock_notice_free);
-#else
   if (self->notices) {
     g_list_free_full(self->notices, (GDestroyNotify)mock_notice_free);
     self->notices = NULL;
   }
-#endif
   g_clear_pointer(&self->notices_parameters, g_free);
 
   g_cond_clear(&self->condition);

--- a/tests/test-glib.c
+++ b/tests/test-glib.c
@@ -792,7 +792,7 @@ static void test_logout_sync(void) {
 
 static void logout_cb(GObject *object, GAsyncResult *result,
                       gpointer user_data) {
-  AsyncData *data = user_data;
+  g_autoptr(AsyncData) data = user_data;
 
   g_autoptr(GError) error = NULL;
   gboolean r = snapd_client_logout_finish(SNAPD_CLIENT(object), result, &error);
@@ -824,7 +824,7 @@ static void test_logout_async(void) {
   snapd_client_set_auth_data(client, auth_data);
 
   g_assert_nonnull(mock_snapd_find_account_by_id(snapd, id));
-  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
+  AsyncData *data = async_data_new(loop, snapd);
   data->id = id;
   snapd_client_logout_async(client, id, NULL, logout_cb, data);
   g_main_loop_run(loop);
@@ -5209,6 +5209,8 @@ static void install_multiple_cb(GObject *object, GAsyncResult *result,
     g_assert_nonnull(mock_snapd_find_snap(data->snapd, "snap3"));
 
     g_main_loop_quit(data->loop);
+
+    async_data_free(data);
   }
 }
 
@@ -5229,7 +5231,7 @@ static void test_install_async_multiple(void) {
   g_assert_null(mock_snapd_find_snap(snapd, "snap1"));
   g_assert_null(mock_snapd_find_snap(snapd, "snap2"));
   g_assert_null(mock_snapd_find_snap(snapd, "snap3"));
-  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
+  AsyncData *data = async_data_new(loop, snapd);
   data->counter = 3;
   snapd_client_install2_async(client, SNAPD_INSTALL_FLAGS_NONE, "snap1", NULL,
                               NULL, NULL, NULL, NULL, install_multiple_cb,
@@ -5321,6 +5323,8 @@ static void complete_async_multiple_cancel_first(AsyncData *data) {
     g_assert_nonnull(mock_snapd_find_snap(data->snapd, "snap3"));
 
     g_main_loop_quit(data->loop);
+
+    async_data_free(data);
   }
 }
 
@@ -5371,7 +5375,7 @@ static void test_install_async_multiple_cancel_first(void) {
   g_assert_null(mock_snapd_find_snap(snapd, "snap2"));
   g_assert_null(mock_snapd_find_snap(snapd, "snap3"));
   g_autoptr(GCancellable) cancellable = g_cancellable_new();
-  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
+  AsyncData *data = async_data_new(loop, snapd);
   data->counter = 3;
   snapd_client_install2_async(client, SNAPD_INSTALL_FLAGS_NONE, "snap1", NULL,
                               NULL, NULL, NULL, cancellable,
@@ -5394,6 +5398,8 @@ static void complete_async_multiple_cancel_last(AsyncData *data) {
     g_assert_null(mock_snapd_find_snap(data->snapd, "snap3"));
 
     g_main_loop_quit(data->loop);
+
+    async_data_free(data);
   }
 }
 
@@ -5444,7 +5450,7 @@ static void test_install_async_multiple_cancel_last(void) {
   g_assert_null(mock_snapd_find_snap(snapd, "snap2"));
   g_assert_null(mock_snapd_find_snap(snapd, "snap3"));
   g_autoptr(GCancellable) cancellable = g_cancellable_new();
-  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
+  AsyncData *data = async_data_new(loop, snapd);
   data->counter = 3;
   snapd_client_install2_async(client, SNAPD_INSTALL_FLAGS_NONE, "snap1", NULL,
                               NULL, NULL, NULL, NULL,
@@ -8514,13 +8520,16 @@ static void test_follow_logs_sync(void) {
 
 static void async_log_cb(SnapdClient *client, SnapdLog *log,
                          gpointer user_data) {
+  // This callback is called several times. Also, the same data
+  // memory block is used in the `follow_logs_cb()` callback.
+  // This is why it must not be freed here.
   AsyncData *data = user_data;
   data->counter++;
 }
 
 static void follow_logs_cb(GObject *object, GAsyncResult *result,
                            gpointer user_data) {
-  AsyncData *data = user_data;
+  g_autoptr(AsyncData) data = user_data;
 
   g_autoptr(GError) error = NULL;
   gboolean r =
@@ -8549,7 +8558,7 @@ static void test_follow_logs_async(void) {
   g_autoptr(SnapdClient) client = snapd_client_new();
   snapd_client_set_socket_path(client, mock_snapd_get_socket_path(snapd));
 
-  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
+  AsyncData *data = async_data_new(loop, snapd);
   snapd_client_follow_logs_async(client, NULL, async_log_cb, data, NULL,
                                  follow_logs_cb, data);
   g_main_loop_run(loop);
@@ -8772,6 +8781,12 @@ static void test_notices_events(void) {
 
   g_autoptr(MockSnapd) snapd = mock_snapd_new();
 
+  // In this case, we define the `data` struct with g_autoptr
+  // because the callback can be called several times, so this
+  // ensures that it is freed only when no more callbacks will be
+  // serviced. We can do this because in this tests we are
+  // using a new mainloop, which only returns after g_main_loop_quit()
+  // has been called.
   g_autoptr(AsyncData) data = async_data_new(loop, snapd);
   g_autoptr(GError) error = NULL;
   g_assert_true(mock_snapd_start(snapd, &error));
@@ -8883,6 +8898,12 @@ static void test_notices_events_with_minimal_data(void) {
 
   g_autoptr(MockSnapd) snapd = mock_snapd_new();
 
+  // In this case, we define the `data` struct with g_autoptr
+  // because the callback can be called several times, so this
+  // ensures that it is freed only when no more callbacks will be
+  // serviced. We can do this because in this tests we are
+  // using a new mainloop, which only returns after g_main_loop_quit()
+  // has been called.
   g_autoptr(AsyncData) data = async_data_new(loop, snapd);
   g_autoptr(GError) error = NULL;
   g_assert_true(mock_snapd_start(snapd, &error));
@@ -9025,7 +9046,7 @@ static void test_get_model_assertion_sync(void) {
 
 static void get_model_assertion_cb(GObject *object, GAsyncResult *result,
                                    gpointer user_data) {
-  AsyncData *data = user_data;
+  g_autoptr(AsyncData) data = user_data;
 
   g_autoptr(GError) error = NULL;
   g_autofree gchar *model_assertion = snapd_client_get_model_assertion_finish(
@@ -9048,7 +9069,7 @@ static void test_get_model_assertion_async(void) {
   g_autoptr(SnapdClient) client = snapd_client_new();
   snapd_client_set_socket_path(client, mock_snapd_get_socket_path(snapd));
 
-  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
+  AsyncData *data = async_data_new(loop, snapd);
   snapd_client_get_model_assertion_async(client, NULL, get_model_assertion_cb,
                                          data);
   g_main_loop_run(loop);
@@ -9072,7 +9093,7 @@ static void test_get_serial_assertion_sync(void) {
 
 static void get_serial_assertion_cb(GObject *object, GAsyncResult *result,
                                     gpointer user_data) {
-  AsyncData *data = user_data;
+  g_autoptr(AsyncData) data = user_data;
 
   g_autoptr(GError) error = NULL;
   g_autofree gchar *serial_assertion = snapd_client_get_serial_assertion_finish(
@@ -9095,7 +9116,7 @@ static void test_get_serial_assertion_async(void) {
   g_autoptr(SnapdClient) client = snapd_client_new();
   snapd_client_set_socket_path(client, mock_snapd_get_socket_path(snapd));
 
-  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
+  AsyncData *data = async_data_new(loop, snapd);
   snapd_client_get_serial_assertion_async(client, NULL, get_serial_assertion_cb,
                                           data);
   g_main_loop_run(loop);

--- a/tests/test-glib.c
+++ b/tests/test-glib.c
@@ -792,7 +792,7 @@ static void test_logout_sync(void) {
 
 static void logout_cb(GObject *object, GAsyncResult *result,
                       gpointer user_data) {
-  g_autoptr(AsyncData) data = user_data;
+  AsyncData *data = user_data;
 
   g_autoptr(GError) error = NULL;
   gboolean r = snapd_client_logout_finish(SNAPD_CLIENT(object), result, &error);
@@ -824,7 +824,7 @@ static void test_logout_async(void) {
   snapd_client_set_auth_data(client, auth_data);
 
   g_assert_nonnull(mock_snapd_find_account_by_id(snapd, id));
-  AsyncData *data = async_data_new(loop, snapd);
+  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
   data->id = id;
   snapd_client_logout_async(client, id, NULL, logout_cb, data);
   g_main_loop_run(loop);
@@ -5209,8 +5209,6 @@ static void install_multiple_cb(GObject *object, GAsyncResult *result,
     g_assert_nonnull(mock_snapd_find_snap(data->snapd, "snap3"));
 
     g_main_loop_quit(data->loop);
-
-    async_data_free(data);
   }
 }
 
@@ -5231,7 +5229,7 @@ static void test_install_async_multiple(void) {
   g_assert_null(mock_snapd_find_snap(snapd, "snap1"));
   g_assert_null(mock_snapd_find_snap(snapd, "snap2"));
   g_assert_null(mock_snapd_find_snap(snapd, "snap3"));
-  AsyncData *data = async_data_new(loop, snapd);
+  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
   data->counter = 3;
   snapd_client_install2_async(client, SNAPD_INSTALL_FLAGS_NONE, "snap1", NULL,
                               NULL, NULL, NULL, NULL, install_multiple_cb,
@@ -5323,8 +5321,6 @@ static void complete_async_multiple_cancel_first(AsyncData *data) {
     g_assert_nonnull(mock_snapd_find_snap(data->snapd, "snap3"));
 
     g_main_loop_quit(data->loop);
-
-    async_data_free(data);
   }
 }
 
@@ -5375,7 +5371,7 @@ static void test_install_async_multiple_cancel_first(void) {
   g_assert_null(mock_snapd_find_snap(snapd, "snap2"));
   g_assert_null(mock_snapd_find_snap(snapd, "snap3"));
   g_autoptr(GCancellable) cancellable = g_cancellable_new();
-  AsyncData *data = async_data_new(loop, snapd);
+  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
   data->counter = 3;
   snapd_client_install2_async(client, SNAPD_INSTALL_FLAGS_NONE, "snap1", NULL,
                               NULL, NULL, NULL, cancellable,
@@ -5398,8 +5394,6 @@ static void complete_async_multiple_cancel_last(AsyncData *data) {
     g_assert_null(mock_snapd_find_snap(data->snapd, "snap3"));
 
     g_main_loop_quit(data->loop);
-
-    async_data_free(data);
   }
 }
 
@@ -5450,7 +5444,7 @@ static void test_install_async_multiple_cancel_last(void) {
   g_assert_null(mock_snapd_find_snap(snapd, "snap2"));
   g_assert_null(mock_snapd_find_snap(snapd, "snap3"));
   g_autoptr(GCancellable) cancellable = g_cancellable_new();
-  AsyncData *data = async_data_new(loop, snapd);
+  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
   data->counter = 3;
   snapd_client_install2_async(client, SNAPD_INSTALL_FLAGS_NONE, "snap1", NULL,
                               NULL, NULL, NULL, NULL,
@@ -8526,7 +8520,7 @@ static void async_log_cb(SnapdClient *client, SnapdLog *log,
 
 static void follow_logs_cb(GObject *object, GAsyncResult *result,
                            gpointer user_data) {
-  g_autoptr(AsyncData) data = user_data;
+  AsyncData *data = user_data;
 
   g_autoptr(GError) error = NULL;
   gboolean r =
@@ -8555,7 +8549,7 @@ static void test_follow_logs_async(void) {
   g_autoptr(SnapdClient) client = snapd_client_new();
   snapd_client_set_socket_path(client, mock_snapd_get_socket_path(snapd));
 
-  AsyncData *data = async_data_new(loop, snapd);
+  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
   snapd_client_follow_logs_async(client, NULL, async_log_cb, data, NULL,
                                  follow_logs_cb, data);
   g_main_loop_run(loop);
@@ -8778,7 +8772,7 @@ static void test_notices_events(void) {
 
   g_autoptr(MockSnapd) snapd = mock_snapd_new();
 
-  AsyncData *data = async_data_new(loop, snapd);
+  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
   g_autoptr(GError) error = NULL;
   g_assert_true(mock_snapd_start(snapd, &error));
 
@@ -8889,7 +8883,7 @@ static void test_notices_events_with_minimal_data(void) {
 
   g_autoptr(MockSnapd) snapd = mock_snapd_new();
 
-  AsyncData *data = async_data_new(loop, snapd);
+  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
   g_autoptr(GError) error = NULL;
   g_assert_true(mock_snapd_start(snapd, &error));
 
@@ -9031,7 +9025,7 @@ static void test_get_model_assertion_sync(void) {
 
 static void get_model_assertion_cb(GObject *object, GAsyncResult *result,
                                    gpointer user_data) {
-  g_autoptr(AsyncData) data = user_data;
+  AsyncData *data = user_data;
 
   g_autoptr(GError) error = NULL;
   g_autofree gchar *model_assertion = snapd_client_get_model_assertion_finish(
@@ -9054,7 +9048,7 @@ static void test_get_model_assertion_async(void) {
   g_autoptr(SnapdClient) client = snapd_client_new();
   snapd_client_set_socket_path(client, mock_snapd_get_socket_path(snapd));
 
-  AsyncData *data = async_data_new(loop, snapd);
+  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
   snapd_client_get_model_assertion_async(client, NULL, get_model_assertion_cb,
                                          data);
   g_main_loop_run(loop);
@@ -9078,7 +9072,7 @@ static void test_get_serial_assertion_sync(void) {
 
 static void get_serial_assertion_cb(GObject *object, GAsyncResult *result,
                                     gpointer user_data) {
-  g_autoptr(AsyncData) data = user_data;
+  AsyncData *data = user_data;
 
   g_autoptr(GError) error = NULL;
   g_autofree gchar *serial_assertion = snapd_client_get_serial_assertion_finish(
@@ -9101,7 +9095,7 @@ static void test_get_serial_assertion_async(void) {
   g_autoptr(SnapdClient) client = snapd_client_new();
   snapd_client_set_socket_path(client, mock_snapd_get_socket_path(snapd));
 
-  AsyncData *data = async_data_new(loop, snapd);
+  g_autoptr(AsyncData) data = async_data_new(loop, snapd);
   snapd_client_get_serial_assertion_async(client, NULL, get_serial_assertion_cb,
                                           data);
   g_main_loop_run(loop);


### PR DESCRIPTION
The snapd mock had some leaks. These patches fix them, to allow to find future leaks more easily.