### PR TITLE
Add static flags to object parameters

### DIFF
--- a/snapd-glib/snapd-alias.c
+++ b/snapd-glib/snapd-alias.c
@@ -252,35 +252,47 @@ static void snapd_alias_class_init(SnapdAliasClass *klass) {
       g_param_spec_string(
           "app-auto", "app-auto",
           "App this alias is for (when status is SNAPD_ALIAS_STATUS_AUTO)",
-          NULL, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+          NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
   g_object_class_install_property(
       gobject_class, PROP_APP_MANUAL,
       g_param_spec_string(
           "app-manual", "app-manual",
           "App this alias is for (when status is SNAPD_ALIAS_STATUS_MANUAL)",
-          NULL, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+          NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
   g_object_class_install_property(
       gobject_class, PROP_COMMAND,
       g_param_spec_string("command", "command", "Command this alias runs", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
 
   g_object_class_install_property(
       gobject_class, PROP_NAME,
       g_param_spec_string("name", "name", "Name of alias", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
 
   g_object_class_install_property(
       gobject_class, PROP_SNAP,
       g_param_spec_string("snap", "snap", "Snap this alias is for", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
 
   g_object_class_install_property(
       gobject_class, PROP_STATUS,
       g_param_spec_enum("status", "status", "Alias status",
                         SNAPD_TYPE_ALIAS_STATUS, SNAPD_ALIAS_STATUS_UNKNOWN,
-                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                            G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                            G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_alias_init(SnapdAlias *self) {}

--- a/snapd-glib/snapd-app.c
+++ b/snapd-glib/snapd-app.c
@@ -271,37 +271,52 @@ static void snapd_app_class_init(SnapdAppClass *klass) {
   g_object_class_install_property(
       gobject_class, PROP_NAME,
       g_param_spec_string("name", "name", "App name", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_ALIASES,
       g_param_spec_boxed("aliases", "aliases", "App aliases", G_TYPE_STRV,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_COMMON_ID,
       g_param_spec_string("common-id", "common-id", "Common ID", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_DAEMON_TYPE,
       g_param_spec_enum("daemon-type", "daemon-type", "Daemon type",
                         SNAPD_TYPE_DAEMON_TYPE, SNAPD_DAEMON_TYPE_UNKNOWN,
-                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                            G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                            G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_DESKTOP_FILE,
-      g_param_spec_string("desktop-file", "desktop-file",
-                          "App desktop file path", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "desktop-file", "desktop-file", "App desktop file path", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SNAP,
       g_param_spec_string("snap", "snap", "Snap name", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_ACTIVE,
       g_param_spec_boolean("active", "active", "TRUE if active", FALSE,
-                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                               G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                               G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_ENABLED,
       g_param_spec_boolean("enabled", "enabled", "TRUE if enabled", FALSE,
-                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                               G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                               G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_app_init(SnapdApp *self) {}

--- a/snapd-glib/snapd-assertion.c
+++ b/snapd-glib/snapd-assertion.c
@@ -278,7 +278,9 @@ static void snapd_assertion_class_init(SnapdAssertionClass *klass) {
   g_object_class_install_property(
       gobject_class, PROP_CONTENT,
       g_param_spec_string("content", "content", "Assertion content", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_assertion_init(SnapdAssertion *self) {}

--- a/snapd-glib/snapd-auth-data.c
+++ b/snapd-glib/snapd-auth-data.c
@@ -147,14 +147,17 @@ static void snapd_auth_data_class_init(SnapdAuthDataClass *klass) {
   gobject_class->get_property = snapd_auth_data_get_property;
   gobject_class->finalize = snapd_auth_data_finalize;
 
-  g_object_class_install_property(gobject_class, PROP_MACAROON,
-                                  g_param_spec_string("macaroon", "macaroon",
-                                                      "Serialized macaroon",
-                                                      NULL, G_PARAM_READWRITE));
+  g_object_class_install_property(
+      gobject_class, PROP_MACAROON,
+      g_param_spec_string("macaroon", "macaroon", "Serialized macaroon", NULL,
+                          G_PARAM_READWRITE | G_PARAM_STATIC_NAME |
+                              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_DISCHARGES,
       g_param_spec_boxed("discharges", "discharges", "Serialized discharges",
-                         G_TYPE_STRV, G_PARAM_READWRITE));
+                         G_TYPE_STRV,
+                         G_PARAM_READWRITE | G_PARAM_STATIC_NAME |
+                             G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_auth_data_init(SnapdAuthData *self) {}

--- a/snapd-glib/snapd-autorefresh-change-data.c
+++ b/snapd-glib/snapd-autorefresh-change-data.c
@@ -151,17 +151,20 @@ static void snapd_autorefresh_change_data_class_init(
 
   g_object_class_install_property(
       gobject_class, PROP_SNAP_NAMES,
-      g_param_spec_boxed("snap-names", "Snap Names",
-                         "Names of the snaps that have been autorefreshed.",
-                         G_TYPE_STRV,
-                         G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
+      g_param_spec_boxed(
+          "snap-names", "Snap Names",
+          "Names of the snaps that have been autorefreshed.", G_TYPE_STRV,
+          G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
   g_object_class_install_property(
       gobject_class, PROP_REFRESH_FORCED,
       g_param_spec_boxed(
           "refresh-forced", "Refresh forced",
           "Names of the snaps that have been forced to autorefresh.",
-          G_TYPE_STRV, G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
+          G_TYPE_STRV,
+          G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
 static void

--- a/snapd-glib/snapd-category-details.c
+++ b/snapd-glib/snapd-category-details.c
@@ -102,7 +102,9 @@ snapd_category_details_class_init(SnapdCategoryDetailsClass *klass) {
   g_object_class_install_property(
       gobject_class, PROP_NAME,
       g_param_spec_string("name", "name", "The category name", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_category_details_init(SnapdCategoryDetails *self) {}

--- a/snapd-glib/snapd-category.c
+++ b/snapd-glib/snapd-category.c
@@ -122,13 +122,16 @@ static void snapd_category_class_init(SnapdCategoryClass *klass) {
 
   g_object_class_install_property(
       gobject_class, PROP_FEATURED,
-      g_param_spec_boolean("featured", "featured",
-                           "TRUE if this category is featured", FALSE,
-                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boolean(
+          "featured", "featured", "TRUE if this category is featured", FALSE,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_NAME,
       g_param_spec_string("name", "name", "The category name", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_category_init(SnapdCategory *self) {}

--- a/snapd-glib/snapd-change.c
+++ b/snapd-glib/snapd-change.c
@@ -331,46 +331,65 @@ static void snapd_change_class_init(SnapdChangeClass *klass) {
   g_object_class_install_property(
       gobject_class, PROP_ID,
       g_param_spec_string("id", "id", "ID of change", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_KIND,
       g_param_spec_string("kind", "kind", "Kind of change", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SUMMARY,
       g_param_spec_string("summary", "summary", "Summary of change", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_STATUS,
       g_param_spec_string("status", "status", "Status of change", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_TASKS,
-      g_param_spec_boxed("tasks", "tasks", "Tasks in this change",
-                         G_TYPE_PTR_ARRAY,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boxed(
+          "tasks", "tasks", "Tasks in this change", G_TYPE_PTR_ARRAY,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_READY,
       g_param_spec_boolean("ready", "ready", "TRUE when change complete", FALSE,
-                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                               G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                               G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SPAWN_TIME,
       g_param_spec_boxed("spawn-time", "spawn-time", "Time this change started",
                          G_TYPE_DATE_TIME,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_READY_TIME,
       g_param_spec_boxed("ready-time", "ready-time",
                          "Time this change completed", G_TYPE_DATE_TIME,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_ERROR,
-      g_param_spec_string("error", "error", "Error associated with change",
-                          NULL, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "error", "error", "Error associated with change", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_DATA,
       g_param_spec_object("data", "data", "Data field", SNAPD_TYPE_CHANGE_DATA,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_change_init(SnapdChange *self) {}

--- a/snapd-glib/snapd-channel.c
+++ b/snapd-glib/snapd-channel.c
@@ -358,37 +358,48 @@ static void snapd_channel_class_init(SnapdChannelClass *klass) {
 
   g_object_class_install_property(
       gobject_class, PROP_CONFINEMENT,
-      g_param_spec_enum("confinement", "confinement",
-                        "Confinement requested by the snap",
-                        SNAPD_TYPE_CONFINEMENT, SNAPD_CONFINEMENT_UNKNOWN,
-                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_enum(
+          "confinement", "confinement", "Confinement requested by the snap",
+          SNAPD_TYPE_CONFINEMENT, SNAPD_CONFINEMENT_UNKNOWN,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_EPOCH,
       g_param_spec_string("epoch", "epoch", "Epoch of this snap", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_NAME,
       g_param_spec_string("name", "name", "The channel name", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_REVISION,
       g_param_spec_string("revision", "revision", "Revision of this snap", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_RELEASED_AT,
-      g_param_spec_boxed("released-at", "released-at",
-                         "Date revision was released into channel",
-                         G_TYPE_DATE_TIME,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boxed(
+          "released-at", "released-at",
+          "Date revision was released into channel", G_TYPE_DATE_TIME,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SIZE,
-      g_param_spec_int64("size", "size", "Download size in bytes", G_MININT64,
-                         G_MAXINT64, 0,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_int64(
+          "size", "size", "Download size in bytes", G_MININT64, G_MAXINT64, 0,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_VERSION,
       g_param_spec_string("version", "version", "Snap version", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_channel_init(SnapdChannel *self) {}

--- a/snapd-glib/snapd-connection.c
+++ b/snapd-glib/snapd-connection.c
@@ -408,47 +408,63 @@ static void snapd_connection_class_init(SnapdConnectionClass *klass) {
 
   g_object_class_install_property(
       gobject_class, PROP_NAME,
-      g_param_spec_string("name", "name", "Name of connection/plug on snap",
-                          NULL, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "name", "name", "Name of connection/plug on snap", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SNAP,
-      g_param_spec_string("snap", "snap", "Snap this connection is made to",
-                          NULL, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "snap", "snap", "Snap this connection is made to", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SLOT,
       g_param_spec_object("slot", "slot", "Slot this connection is made with",
                           SNAPD_TYPE_SLOT_REF,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_PLUG,
       g_param_spec_object("plug", "plug", "Plug this connection is made with",
                           SNAPD_TYPE_PLUG_REF,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_INTERFACE,
-      g_param_spec_string("interface", "interface",
-                          "Interface this connection uses", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "interface", "interface", "Interface this connection uses", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_MANUAL,
-      g_param_spec_boolean("manual", "manual",
-                           "TRUE if connection was made manually", FALSE,
-                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boolean(
+          "manual", "manual", "TRUE if connection was made manually", FALSE,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_GADGET,
-      g_param_spec_boolean("gadget", "gadget",
-                           "TRUE if connection was made by the gadget snap",
-                           FALSE, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boolean(
+          "gadget", "gadget", "TRUE if connection was made by the gadget snap",
+          FALSE,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SLOT_ATTRIBUTES,
       g_param_spec_boxed("slot-attrs", "slot-attrs",
                          "Attributes for connected slot", G_TYPE_HASH_TABLE,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_PLUG_ATTRIBUTES,
       g_param_spec_boxed("plug-attrs", "plug-attrs",
                          "Attributes for connected plug", G_TYPE_HASH_TABLE,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_connection_init(SnapdConnection *self) {}

--- a/snapd-glib/snapd-icon.c
+++ b/snapd-glib/snapd-icon.c
@@ -125,11 +125,15 @@ static void snapd_icon_class_init(SnapdIconClass *klass) {
   g_object_class_install_property(
       gobject_class, PROP_MIME_TYPE,
       g_param_spec_string("mime-type", "mime-type", "Icon mime type", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_DATA,
       g_param_spec_boxed("data", "data", "Icon data", G_TYPE_BYTES,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_icon_init(SnapdIcon *self) {}

--- a/snapd-glib/snapd-interface.c
+++ b/snapd-glib/snapd-interface.c
@@ -341,25 +341,33 @@ static void snapd_interface_class_init(SnapdInterfaceClass *klass) {
   g_object_class_install_property(
       gobject_class, PROP_NAME,
       g_param_spec_string("name", "name", "Interface name", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SUMMARY,
       g_param_spec_string("summary", "summary", "Interface summary", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_DOC_URL,
-      g_param_spec_string("doc-url", "doc-url", "Interface documentation URL",
-                          NULL, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "doc-url", "doc-url", "Interface documentation URL", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_PLUGS,
-      g_param_spec_boxed("plugs", "plugs", "Plugs of this interface type",
-                         G_TYPE_PTR_ARRAY,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boxed(
+          "plugs", "plugs", "Plugs of this interface type", G_TYPE_PTR_ARRAY,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SLOTS,
-      g_param_spec_boxed("slots", "slots", "Slots of this interface type",
-                         G_TYPE_PTR_ARRAY,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boxed(
+          "slots", "slots", "Slots of this interface type", G_TYPE_PTR_ARRAY,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_interface_init(SnapdInterface *self) {}

--- a/snapd-glib/snapd-log.c
+++ b/snapd-glib/snapd-log.c
@@ -172,21 +172,28 @@ static void snapd_log_class_init(SnapdLogClass *klass) {
 
   g_object_class_install_property(
       gobject_class, PROP_TIMESTAMP,
-      g_param_spec_boxed("timestamp", "timestamp", "Timestamp",
-                         G_TYPE_DATE_TIME,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boxed(
+          "timestamp", "timestamp", "Timestamp", G_TYPE_DATE_TIME,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_MESSAGE,
       g_param_spec_string("message", "message", "Message", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SID,
       g_param_spec_string("sid", "sid", "Syslog ID", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_PID,
       g_param_spec_string("pid", "pid", "Process ID", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_log_init(SnapdLog *self) {}

--- a/snapd-glib/snapd-maintenance.c
+++ b/snapd-glib/snapd-maintenance.c
@@ -126,14 +126,17 @@ static void snapd_maintenance_class_init(SnapdMaintenanceClass *klass) {
 
   g_object_class_install_property(
       gobject_class, PROP_KIND,
-      g_param_spec_enum("kind", "kind", "Maintenance kind",
-                        SNAPD_TYPE_MAINTENANCE_KIND,
-                        SNAPD_MAINTENANCE_KIND_UNKNOWN,
-                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_enum(
+          "kind", "kind", "Maintenance kind", SNAPD_TYPE_MAINTENANCE_KIND,
+          SNAPD_MAINTENANCE_KIND_UNKNOWN,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_MESSAGE,
       g_param_spec_string("message", "message", "User readable message", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_maintenance_init(SnapdMaintenance *self) {}

--- a/snapd-glib/snapd-markdown-node.c
+++ b/snapd-glib/snapd-markdown-node.c
@@ -105,16 +105,21 @@ static void snapd_markdown_node_class_init(SnapdMarkdownNodeClass *klass) {
       gobject_class, PROP_NODE_TYPE,
       g_param_spec_enum("node-type", "node-type", "Type of node",
                         SNAPD_TYPE_MARKDOWN_NODE_TYPE, 0,
-                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                            G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                            G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_TEXT,
       g_param_spec_string("text", "text", "Text this node contains", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_CHILDREN,
-      g_param_spec_boxed("children", "children", "Child nodes",
-                         G_TYPE_PTR_ARRAY,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boxed(
+          "children", "children", "Child nodes", G_TYPE_PTR_ARRAY,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_markdown_node_init(SnapdMarkdownNode *self) {}

--- a/snapd-glib/snapd-media.c
+++ b/snapd-glib/snapd-media.c
@@ -170,21 +170,27 @@ static void snapd_media_class_init(SnapdMediaClass *klass) {
   g_object_class_install_property(
       gobject_class, PROP_TYPE,
       g_param_spec_string("type", "type", "Type for this media", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_URL,
       g_param_spec_string("url", "url", "URL for this media", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_WIDTH,
-      g_param_spec_uint("width", "width", "Width of media in pixels", 0,
-                        G_MAXUINT, 0,
-                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_uint(
+          "width", "width", "Width of media in pixels", 0, G_MAXUINT, 0,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_HEIGHT,
-      g_param_spec_uint("height", "height", "Height of media in pixels", 0,
-                        G_MAXUINT, 0,
-                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_uint(
+          "height", "height", "Height of media in pixels", 0, G_MAXUINT, 0,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_media_init(SnapdMedia *self) {}

--- a/snapd-glib/snapd-notice.c
+++ b/snapd-glib/snapd-notice.c
@@ -499,69 +499,91 @@ static void snapd_notice_class_init(SnapdNoticeClass *klass) {
   g_object_class_install_property(
       gobject_class, PROP_ID,
       g_param_spec_string("id", "id", "ID of notice", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_USER_ID,
       g_param_spec_string(
           "user-id", "user-id",
           "UserID of the user who may view this notice (NULL means all users)",
-          NULL, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+          NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_TYPE,
-      g_param_spec_uint("notice-type", "notice-type", "Type of notice", 0,
-                        G_MAXUINT, 0,
-                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_uint(
+          "notice-type", "notice-type", "Type of notice", 0, G_MAXUINT, 0,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_KEY,
       g_param_spec_string("key", "key", "Key of notice", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_FIRST_OCCURRED,
       g_param_spec_boxed("first-occurred", "first-occurred",
                          "Time this notice first occurred", G_TYPE_DATE_TIME,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_LAST_OCCURRED,
       g_param_spec_boxed("last-occurred", "last-occurred",
                          "Time this notice last occurred", G_TYPE_DATE_TIME,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_LAST_OCCURRED_NANO,
       g_param_spec_int("last-occurred-nanoseconds", "last-occurred-nanoseconds",
                        "Time this notice last ocurred, in string format and "
                        "with nanosecond accuracy",
                        -1, 999999999, -1,
-                       G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                       G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                           G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                           G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_LAST_REPEATED,
       g_param_spec_boxed("last-repeated", "last-repeated",
                          "Time this notice was last repeated", G_TYPE_DATE_TIME,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_OCCURRENCES,
       g_param_spec_int64("occurrences", "occurrences",
                          "Number of time one of these notices has occurred",
                          G_MININT, G_MAXINT, -1,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_LAST_DATA,
-      g_param_spec_boxed("last-data", "last-data", "Data for this notice",
-                         G_TYPE_HASH_TABLE,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boxed(
+          "last-data", "last-data", "Data for this notice", G_TYPE_HASH_TABLE,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_REPEAT_AFTER,
       g_param_spec_int64("repeat-after", "repeat-after",
                          "Time (in ms) after one of these was last repeated "
                          "should we allow it to repeat",
                          G_MININT64, G_MAXINT64, 0,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_EXPIRE_AFTER,
       g_param_spec_int64("expire-after", "expire-after",
                          "Time (in ms) since one of these last occurred until "
                          "we should drop the notice",
                          G_MININT64, G_MAXINT64, 0,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_notice_init(SnapdNotice *self) {

--- a/snapd-glib/snapd-notices-monitor.c
+++ b/snapd-glib/snapd-notices-monitor.c
@@ -193,7 +193,9 @@ static void snapd_notices_monitor_class_init(SnapdNoticesMonitorClass *klass) {
       gobject_class, PROP_CLIENT,
       g_param_spec_object(
           "client", "client", "SnapdClient to use to communicate",
-          SNAPD_TYPE_CLIENT, G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+          SNAPD_TYPE_CLIENT,
+          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
   g_signal_new("notice-event", G_TYPE_FROM_CLASS(klass), G_SIGNAL_RUN_LAST, 0,
                NULL, NULL, NULL, G_TYPE_NONE, 2, SNAPD_TYPE_NOTICE,

--- a/snapd-glib/snapd-plug-ref.c
+++ b/snapd-glib/snapd-plug-ref.c
@@ -124,11 +124,15 @@ static void snapd_plug_ref_class_init(SnapdPlugRefClass *klass) {
   g_object_class_install_property(
       gobject_class, PROP_PLUG,
       g_param_spec_string("plug", "plug", "Name of plug", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SNAP,
       g_param_spec_string("snap", "snap", "Snap this plug is on", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_plug_ref_init(SnapdPlugRef *self) {}

--- a/snapd-glib/snapd-plug.c
+++ b/snapd-glib/snapd-plug.c
@@ -319,30 +319,41 @@ static void snapd_plug_class_init(SnapdPlugClass *klass) {
   g_object_class_install_property(
       gobject_class, PROP_NAME,
       g_param_spec_string("name", "name", "Plug name", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SNAP,
       g_param_spec_string("snap", "snap", "Snap this plug is on", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_INTERFACE,
-      g_param_spec_string("interface", "interface",
-                          "Interface this plug provides", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "interface", "interface", "Interface this plug provides", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_LABEL,
-      g_param_spec_string("label", "label", "Short description of this plug",
-                          NULL, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "label", "label", "Short description of this plug", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_CONNECTIONS,
       g_param_spec_boxed("connections", "connections",
                          "Connections with this plug", G_TYPE_PTR_ARRAY,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_ATTRIBUTES,
       g_param_spec_boxed("attributes", "attributes", "Attributes for this plug",
                          G_TYPE_HASH_TABLE,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_plug_init(SnapdPlug *self) {

--- a/snapd-glib/snapd-price.c
+++ b/snapd-glib/snapd-price.c
@@ -120,13 +120,16 @@ static void snapd_price_class_init(SnapdPriceClass *klass) {
 
   g_object_class_install_property(
       gobject_class, PROP_AMOUNT,
-      g_param_spec_double("amount", "amount", "Amount of price", 0.0,
-                          G_MAXDOUBLE, 0.0,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_double(
+          "amount", "amount", "Amount of price", 0.0, G_MAXDOUBLE, 0.0,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_CURRENCY,
       g_param_spec_string("currency", "currency", "Currency amount is in", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_price_init(SnapdPrice *self) {}

--- a/snapd-glib/snapd-screenshot.c
+++ b/snapd-glib/snapd-screenshot.c
@@ -147,17 +147,21 @@ static void snapd_screenshot_class_init(SnapdScreenshotClass *klass) {
   g_object_class_install_property(
       gobject_class, PROP_URL,
       g_param_spec_string("url", "url", "URL for this screenshot", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_WIDTH,
-      g_param_spec_uint("width", "width", "Width of screenshot in pixels", 0,
-                        G_MAXUINT, 0,
-                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_uint(
+          "width", "width", "Width of screenshot in pixels", 0, G_MAXUINT, 0,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_HEIGHT,
-      g_param_spec_uint("height", "height", "Height of screenshot in pixels", 0,
-                        G_MAXUINT, 0,
-                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_uint(
+          "height", "height", "Height of screenshot in pixels", 0, G_MAXUINT, 0,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_screenshot_init(SnapdScreenshot *self) {}

--- a/snapd-glib/snapd-slot-ref.c
+++ b/snapd-glib/snapd-slot-ref.c
@@ -124,11 +124,15 @@ static void snapd_slot_ref_class_init(SnapdSlotRefClass *klass) {
   g_object_class_install_property(
       gobject_class, PROP_SLOT,
       g_param_spec_string("slot", "slot", "Name of slot", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SNAP,
       g_param_spec_string("snap", "snap", "Snap this slot is on", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_slot_ref_init(SnapdSlotRef *self) {}

--- a/snapd-glib/snapd-slot.c
+++ b/snapd-glib/snapd-slot.c
@@ -319,30 +319,41 @@ static void snapd_slot_class_init(SnapdSlotClass *klass) {
   g_object_class_install_property(
       gobject_class, PROP_NAME,
       g_param_spec_string("name", "name", "Slot name", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SNAP,
       g_param_spec_string("snap", "snap", "Snap this slot is on", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_INTERFACE,
-      g_param_spec_string("interface", "interface",
-                          "Interface this slot consumes", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "interface", "interface", "Interface this slot consumes", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_LABEL,
-      g_param_spec_string("label", "label", "Short description of this slot",
-                          NULL, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "label", "label", "Short description of this slot", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_CONNECTIONS,
       g_param_spec_boxed("connections", "connections",
                          "Connections with this slot", G_TYPE_PTR_ARRAY,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_ATTRIBUTES,
       g_param_spec_boxed("attributes", "attributes", "Attributes for this slot",
                          G_TYPE_HASH_TABLE,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_slot_init(SnapdSlot *self) {

--- a/snapd-glib/snapd-snap.c
+++ b/snapd-glib/snapd-snap.c
@@ -1186,206 +1186,280 @@ static void snapd_snap_class_init(SnapdSnapClass *klass) {
 
   g_object_class_install_property(
       gobject_class, PROP_APPS,
-      g_param_spec_boxed("apps", "apps", "Apps this snap contains",
-                         G_TYPE_PTR_ARRAY,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boxed(
+          "apps", "apps", "Apps this snap contains", G_TYPE_PTR_ARRAY,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_CATEGORIES,
       g_param_spec_boxed("categories", "categories",
                          "Categories this snap belongs to", G_TYPE_PTR_ARRAY,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_BASE,
       g_param_spec_string("base", "base", "Base snap this snap uses", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_BROKEN,
-      g_param_spec_string("broken", "broken", "Error string if snap is broken",
-                          NULL, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "broken", "broken", "Error string if snap is broken", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_CHANNEL,
-      g_param_spec_string("channel", "channel", "Channel the snap is from",
-                          NULL, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "channel", "channel", "Channel the snap is from", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_CHANNELS,
       g_param_spec_boxed("channels", "channels",
                          "Channels this snap is available on", G_TYPE_PTR_ARRAY,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_COMMON_IDS,
       g_param_spec_boxed("common-ids", "common-ids", "Common IDs", G_TYPE_STRV,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_CONFINEMENT,
-      g_param_spec_enum("confinement", "confinement",
-                        "Confinement requested by the snap",
-                        SNAPD_TYPE_CONFINEMENT, SNAPD_CONFINEMENT_UNKNOWN,
-                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_enum(
+          "confinement", "confinement", "Confinement requested by the snap",
+          SNAPD_TYPE_CONFINEMENT, SNAPD_CONFINEMENT_UNKNOWN,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_CONTACT,
-      g_param_spec_string("contact", "contact",
-                          "Method of contacting developer", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "contact", "contact", "Method of contacting developer", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_DESCRIPTION,
-      g_param_spec_string("description", "description",
-                          "Description of the snap", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "description", "description", "Description of the snap", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_DEVELOPER,
-      g_param_spec_string(
-          "developer", "developer", "Developer who created the snap", NULL,
-          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_DEPRECATED));
+      g_param_spec_string("developer", "developer",
+                          "Developer who created the snap", NULL,
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_DEPRECATED | G_PARAM_STATIC_NAME |
+                              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_DEVMODE,
-      g_param_spec_boolean("devmode", "devmode",
-                           "TRUE if the snap is currently installed in devmode",
-                           FALSE, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boolean(
+          "devmode", "devmode",
+          "TRUE if the snap is currently installed in devmode", FALSE,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_DOWNLOAD_SIZE,
       g_param_spec_int64("download-size", "download-size",
                          "Download size in bytes", G_MININT64, G_MAXINT64, 0,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_HOLD,
       g_param_spec_boxed(
           "hold", "hold", "Date this snap will re-enable automatic refreshing",
-          G_TYPE_DATE_TIME, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+          G_TYPE_DATE_TIME,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_PROCEED_TIME,
       g_param_spec_boxed("proceed-time", "proceed-time",
                          "Describes time after which a refresh is forced for a "
                          "running snap in the next auto-refresh.",
                          G_TYPE_DATE_TIME,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_ICON,
       g_param_spec_string("icon", "icon", "URL to the snap icon", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_ID,
       g_param_spec_string("id", "id", "Unique ID for this snap", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_INSTALL_DATE,
       g_param_spec_boxed("install-date", "install-date",
                          "Date this snap was installed", G_TYPE_DATE_TIME,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_INSTALLED_SIZE,
       g_param_spec_int64("installed-size", "installed-size",
                          "Installed size in bytes", G_MININT64, G_MAXINT64, 0,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_JAILMODE,
       g_param_spec_boolean(
           "jailmode", "jailmode",
           "TRUE if the snap is currently installed in jailmode", FALSE,
-          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_LICENSE,
-      g_param_spec_string("license", "license",
-                          "The snap license as an SPDX expression", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "license", "license", "The snap license as an SPDX expression", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_MEDIA,
-      g_param_spec_boxed("media", "media", "Media associated with this snap",
-                         G_TYPE_PTR_ARRAY,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boxed(
+          "media", "media", "Media associated with this snap", G_TYPE_PTR_ARRAY,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_MOUNTED_FROM,
-      g_param_spec_string("mounted-from", "mounted-from",
-                          "Path snap is mounted from", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "mounted-from", "mounted-from", "Path snap is mounted from", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_NAME,
       g_param_spec_string("name", "name", "The snap name", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_PRICES,
       g_param_spec_boxed(
           "prices", "prices", "Prices this snap can be purchased for",
-          G_TYPE_PTR_ARRAY, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+          G_TYPE_PTR_ARRAY,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_PRIVATE,
-      g_param_spec_boolean("private", "private",
-                           "TRUE if this snap is only available to its author",
-                           FALSE, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boolean(
+          "private", "private",
+          "TRUE if this snap is only available to its author", FALSE,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_PUBLISHER_DISPLAY_NAME,
       g_param_spec_string("publisher-display-name", "publisher-display-name",
                           "Display name for snap publisher", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_PUBLISHER_ID,
-      g_param_spec_string("publisher-id", "publisher-id",
-                          "ID for snap publisher", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "publisher-id", "publisher-id", "ID for snap publisher", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_PUBLISHER_USERNAME,
       g_param_spec_string("publisher-username", "publisher-username",
                           "Username for snap publisher", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_PUBLISHER_VALIDATION,
-      g_param_spec_enum("publisher-validation", "publisher-validation",
-                        "Validation for snap publisher",
-                        SNAPD_TYPE_PUBLISHER_VALIDATION,
-                        SNAPD_PUBLISHER_VALIDATION_UNKNOWN,
-                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_enum(
+          "publisher-validation", "publisher-validation",
+          "Validation for snap publisher", SNAPD_TYPE_PUBLISHER_VALIDATION,
+          SNAPD_PUBLISHER_VALIDATION_UNKNOWN,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_REVISION,
       g_param_spec_string("revision", "revision", "Revision of this snap", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SCREENSHOTS,
       g_param_spec_boxed("screenshots", "screenshots",
                          "Screenshots of this snap", G_TYPE_PTR_ARRAY,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_STATUS,
       g_param_spec_enum("status", "status", "State of this snap",
                         SNAPD_TYPE_SNAP_STATUS, SNAPD_SNAP_STATUS_UNKNOWN,
-                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                            G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                            G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SUMMARY,
       g_param_spec_string("summary", "summary", "One line description", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_STORE_URL,
       g_param_spec_string("store-url", "store-url", "Web store URL", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_TITLE,
       g_param_spec_string("title", "title", "The snap title", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_TRACKING_CHANNEL,
       g_param_spec_string("tracking-channel", "tracking-channel",
                           "Channel the snap is currently tracking", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_TRACKS,
       g_param_spec_boxed("tracks", "tracks", "Track names", G_TYPE_STRV,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_TRYMODE,
       g_param_spec_boolean("trymode", "trymode",
                            "TRUE if this snap is installed in try mode", FALSE,
-                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                               G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                               G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SNAP_TYPE,
       g_param_spec_enum("snap-type", "snap-type", "Snap type",
                         SNAPD_TYPE_SNAP_TYPE, SNAPD_SNAP_TYPE_UNKNOWN,
-                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                            G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                            G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_VERSION,
       g_param_spec_string("version", "version", "Snap version", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_WEBSITE,
       g_param_spec_string("website", "website", "Website of developer", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_snap_init(SnapdSnap *self) {}

--- a/snapd-glib/snapd-system-information.c
+++ b/snapd-glib/snapd-system-information.c
@@ -575,94 +575,125 @@ snapd_system_information_class_init(SnapdSystemInformationClass *klass) {
 
   g_object_class_install_property(
       gobject_class, PROP_ARCHITECTURE,
-      g_param_spec_string("architecture", "architecture", "System architecture",
-                          NULL, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "architecture", "architecture", "System architecture", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_BINARIES_DIRECTORY,
       g_param_spec_string("binaries-directory", "binaries-directory",
                           "Directory with snap binaries", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_BUILD_ID,
-      g_param_spec_string("build-id", "build-id",
-                          "Unique build ID for snap build", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "build-id", "build-id", "Unique build ID for snap build", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_CONFINEMENT,
       g_param_spec_enum(
           "confinement", "confinement", "Confinement level supported by system",
           SNAPD_TYPE_SYSTEM_CONFINEMENT, SNAPD_SYSTEM_CONFINEMENT_UNKNOWN,
-          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_KERNEL_VERSION,
-      g_param_spec_string("kernel-version", "kernel-version", "Kernel version",
-                          NULL, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "kernel-version", "kernel-version", "Kernel version", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_MANAGED,
-      g_param_spec_boolean("managed", "managed",
-                           "TRUE if snapd managing the system", FALSE,
-                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boolean(
+          "managed", "managed", "TRUE if snapd managing the system", FALSE,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_MOUNT_DIRECTORY,
       g_param_spec_string("mount-directory", "mount-directory",
                           "Directory snaps are mounted in", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_ON_CLASSIC,
       g_param_spec_boolean("on-classic", "on-classic",
                            "TRUE if running in a classic system", FALSE,
-                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                               G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                               G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_OS_ID,
       g_param_spec_string("os-id", "os-id", "Operating system ID", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_OS_VERSION,
-      g_param_spec_string("os-version", "os-version",
-                          "Operating system version", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "os-version", "os-version", "Operating system version", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_REFRESH_HOLD,
       g_param_spec_boxed("refresh-hold", "refresh-hold",
                          "Time refreshes will be applied", G_TYPE_DATE_TIME,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_REFRESH_LAST,
       g_param_spec_boxed("refresh-last", "refresh-last",
                          "Last time a refresh occurred", G_TYPE_DATE_TIME,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_REFRESH_NEXT,
-      g_param_spec_boxed("refresh-next", "refresh-next",
-                         "Next time a refresh is scheduled for",
-                         G_TYPE_DATE_TIME,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_boxed(
+          "refresh-next", "refresh-next",
+          "Next time a refresh is scheduled for", G_TYPE_DATE_TIME,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_REFRESH_SCHEDULE,
-      g_param_spec_string("refresh-schedule", "refresh-schedule",
-                          "Refresh schedule", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "refresh-schedule", "refresh-schedule", "Refresh schedule", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_REFRESH_TIMER,
-      g_param_spec_string("refresh-timer", "refresh-timer", "Refresh timer",
-                          NULL, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "refresh-timer", "refresh-timer", "Refresh timer", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SANDBOX_FEATURES,
-      g_param_spec_pointer("sandbox-features", "sandbox-features",
-                           "Sandbox features",
-                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_pointer(
+          "sandbox-features", "sandbox-features", "Sandbox features",
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SERIES,
       g_param_spec_string("series", "series", "Snappy release series", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_STORE,
       g_param_spec_string("store", "store", "Snap store", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_VERSION,
       g_param_spec_string("version", "version", "Snappy version", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_system_information_init(SnapdSystemInformation *self) {

--- a/snapd-glib/snapd-task-data.c
+++ b/snapd-glib/snapd-task-data.c
@@ -100,7 +100,9 @@ static void snapd_task_data_class_init(SnapdTaskDataClass *klass) {
       gobject_class, PROP_AFFECTED_SNAPS,
       g_param_spec_boxed("affected-snaps", "affected-snaps",
                          "Snaps affected by this task", G_TYPE_STRV,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_task_data_init(SnapdTaskData *self) {}

--- a/snapd-glib/snapd-task.c
+++ b/snapd-glib/snapd-task.c
@@ -390,55 +390,73 @@ static void snapd_task_class_init(SnapdTaskClass *klass) {
   g_object_class_install_property(
       gobject_class, PROP_ID,
       g_param_spec_string("id", "id", "ID of task", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_KIND,
       g_param_spec_string("kind", "kind", "Kind of task", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SUMMARY,
       g_param_spec_string("summary", "summary", "Summary of task", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_STATUS,
       g_param_spec_string("status", "status", "Status of task", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_PROGRESS_LABEL,
-      g_param_spec_string("progress-label", "progress-label",
-                          "Label for progress", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_string(
+          "progress-label", "progress-label", "Label for progress", NULL,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_PROGRESS_DONE,
       g_param_spec_int64("progress-done", "progress-done",
                          "Number of items done in this task", 0, G_MAXINT64, 0,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_PROGRESS_TOTAL,
-      g_param_spec_int64("progress-total", "progress-total",
-                         "Total number of items to be done in this task", 0,
-                         G_MAXINT64, 0,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_int64(
+          "progress-total", "progress-total",
+          "Total number of items to be done in this task", 0, G_MAXINT64, 0,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_READY,
       g_param_spec_boolean("ready", "ready", "TRUE when task complete", FALSE,
                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
-                               G_PARAM_DEPRECATED));
+                               G_PARAM_DEPRECATED | G_PARAM_STATIC_NAME |
+                               G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SPAWN_TIME,
       g_param_spec_boxed("spawn-time", "spawn-time", "Time this task started",
                          G_TYPE_DATE_TIME,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_READY_TIME,
       g_param_spec_boxed("ready-time", "ready-time", "Time this task completed",
                          G_TYPE_DATE_TIME,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_DATA,
-      g_param_spec_object("data", "data", "Extra data of task",
-                          SNAPD_TYPE_TASK_DATA,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_object(
+          "data", "data", "Extra data of task", SNAPD_TYPE_TASK_DATA,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_task_init(SnapdTask *self) {}

--- a/snapd-glib/snapd-user-information.c
+++ b/snapd-glib/snapd-user-information.c
@@ -206,24 +206,33 @@ snapd_user_information_class_init(SnapdUserInformationClass *klass) {
   g_object_class_install_property(
       gobject_class, PROP_ID,
       g_param_spec_int64("id", "id", "Account id", G_MININT64, G_MAXINT64, -1,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_USERNAME,
       g_param_spec_string("username", "username", "Unix username", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_EMAIL,
       g_param_spec_string("email", "email", "Email address", NULL,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                              G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                              G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_SSH_KEYS,
       g_param_spec_boxed("ssh-keys", "ssh-keys", "SSH keys", G_TYPE_STRV,
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
+                             G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
+                             G_PARAM_STATIC_BLURB));
   g_object_class_install_property(
       gobject_class, PROP_AUTH_DATA,
-      g_param_spec_object("auth-data", "auth-data", "Authorization data",
-                          SNAPD_TYPE_AUTH_DATA,
-                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+      g_param_spec_object(
+          "auth-data", "auth-data", "Authorization data", SNAPD_TYPE_AUTH_DATA,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME |
+              G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 }
 
 static void snapd_user_information_init(SnapdUserInformation *self) {


### PR DESCRIPTION
Adds G_PARAM_STATIC_NAME, G_PARAM_STATIC_NICK and/or G_PARAM_STATIC_BLURB when defining object parameters with static strings, to reduce the memory footprint and show less "still reachable blocks" in Valgrind, which will help when debugging memory leaks.