### PR TITLE
Added test support for "after"

### DIFF
--- a/snapd-glib/requests/snapd-get-notices.c
+++ b/snapd-glib/requests/snapd-get-notices.c
@@ -74,7 +74,15 @@ static SoupMessage *generate_get_snap_request(SnapdRequest *request,
   if (self->since_date_time != NULL) {
     g_autofree gchar *date_time = NULL;
     if (self->since_date_time_nanoseconds == -1) {
+#if GLIB_CHECK_VERSION(2, 66, 0)
       date_time = g_date_time_format(self->since_date_time, "%FT%T.%f%:z");
+#else
+      // g_date_time_format doesn't support %f before GLib 2.66
+      g_autofree gchar *date_time_tmp =
+          g_date_time_format(self->since_date_time, "%FT%T.%%06d%:z");
+      date_time = g_strdup_printf(
+          date_time_tmp, g_date_time_get_microsecond(self->since_date_time));
+#endif
     } else {
       if (self->since_date_time_nanoseconds == 0) {
         date_time = g_date_time_format(self->since_date_time, "%FT%T%:z");

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -20,6 +20,53 @@
 
 #include "mock-snapd.h"
 
+#if !GLIB_CHECK_VERSION(2, 66, 0)
+
+#define HEX_CHAR_TO_NUMBER(c) (((c) < 'a') ? (c) - '0' : ((c) - 'a' + 10))
+
+// a quick&dirty replacement to allow the tests to work, since g_uri_parse_params
+// wasn't added until GLib 2.66
+
+// Replaces in-place any %XY token with the corresponding 0xXY byte
+static void parse_string(gchar *str) {
+  gchar *from = str;
+  gchar *to = str;
+
+  for (; *from != 0; from++, to++) {
+    if (*from != '%') {
+      *to = *from;
+      continue;
+    }
+    from++; // jump over '%' character
+        // set bit 5 to convert letters to lowercase (numbers are unaffected)
+    *from |= 32;
+    gchar value = 16 * HEX_CHAR_TO_NUMBER(*from);
+    from++;
+    *from |= 32;
+    value += HEX_CHAR_TO_NUMBER(*from);
+    *to = value;
+  }
+  *to = 0;
+}
+
+GHashTable *g_uri_parse_params(const gchar *params, gssize lenght,
+                               const gchar *separators, int flags,
+                               GError **error) {
+  g_auto(GStrv) param_list = g_strsplit(params, "&", 0);
+  GHashTable *table =
+      g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+
+  for (GStrv p = param_list; *p != NULL; p++) {
+    g_auto(GStrv) param = g_strsplit(*p, "=", 0);
+    parse_string(param[0]);
+    parse_string(param[1]);
+    g_hash_table_insert(table, g_strdup(param[0]), g_strdup(param[1]));
+  }
+  return table;
+}
+
+#endif
+
 /* For soup 2 pretend to use the new server API */
 #if !SOUP_CHECK_VERSION(2, 99, 2)
 typedef SoupMessage SoupServerMessage;
@@ -420,6 +467,31 @@ static void mock_snap_free(MockSnap *snap) {
   g_free(snap->snap_path);
   g_free(snap->error);
   g_slice_free(MockSnap, snap);
+}
+
+static gint compare_date_time_with_nanoseconds(GDateTime *date1,
+                                               gint date1_nanoseconds,
+                                               GDateTime *date2,
+                                               gint date2_nanoseconds) {
+  g_return_val_if_fail(date1 != NULL, 0);
+  g_return_val_if_fail(date2 != NULL, 0);
+
+  // first, compare without micro/nanoseconds. This is a must to avoid errors
+  // due to rounding, because the g_date_time objects are created using a
+  // gdouble.
+  gint c = g_date_time_compare(date1, date2);
+  if (c != 0)
+    return c;
+  // now take into account the nanoseconds if available
+  if (date1_nanoseconds == -1)
+    date1_nanoseconds = 1000 * g_date_time_get_microsecond(date1);
+  if (date2_nanoseconds == -1)
+    date2_nanoseconds = 1000 * g_date_time_get_microsecond(date2);
+  if (date1_nanoseconds < date2_nanoseconds)
+    return -1;
+  if (date1_nanoseconds == date2_nanoseconds)
+    return 0;
+  return 1;
 }
 
 MockSnapd *mock_snapd_new(void) { return g_object_new(MOCK_TYPE_SNAPD, NULL); }
@@ -4894,8 +4966,35 @@ static void handle_notices(MockSnapd *self, SoupServerMessage *message,
   g_autoptr(JsonBuilder) builder = json_builder_new();
   json_builder_begin_array(builder);
 
+  g_autoptr(GDateTime) after = NULL;
+  guint after_nanoseconds = -1;
+
+  // Check if the petition has an "after" parameter
+  if (self->notices_parameters != NULL) {
+    g_autoptr(GHashTable) parameters = g_uri_parse_params(
+        self->notices_parameters, -1, "&", G_URI_PARAMS_NONE, NULL);
+    if (g_hash_table_contains(parameters, "after")) {
+      g_autofree gchar *after_str =
+          g_strdup(g_hash_table_lookup(parameters, "after"));
+      after = g_date_time_new_from_iso8601(after_str, NULL);
+      gchar *dot_pos = strchr(after_str, '.');
+      after_nanoseconds = (dot_pos == NULL) ? 0 : atoi(1 + dot_pos);
+    }
+  }
+
+  // Send the notices
   for (GList *link = self->notices; link; link = link->next) {
     MockNotice *notice = link->data;
+
+    // but if there is an "after" parameter, send only those that
+    // happened after the specified date-time
+    if ((after != NULL) && (notice->last_occurred != NULL) &&
+        (compare_date_time_with_nanoseconds(notice->last_occurred,
+                                            notice->last_occurred_nanoseconds,
+                                            after, after_nanoseconds) <= 0)) {
+      continue;
+    }
+
     json_builder_begin_object(builder);
     json_builder_set_member_name(builder, "id");
     json_builder_add_string_value(builder, notice->id);

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -22,13 +22,17 @@
 
 #if !GLIB_CHECK_VERSION(2, 66, 0)
 
+// Transforms an ASCII, one-digit, lowercase hexadecimal number into
+// its value.
 #define HEX_CHAR_TO_NUMBER(c) (((c) < 'a') ? (c) - '0' : ((c) - 'a' + 10))
 
 // a quick&dirty replacement to allow the tests to work, since g_uri_parse_params
 // wasn't added until GLib 2.66
 
-// Replaces in-place any %XY token with the corresponding 0xXY byte
-static void parse_string(gchar *str) {
+// Replaces IN-PLACE any %XY token with the corresponding 0xXY byte.
+// The passed string is modified, so it must be a memory block that belongs
+// to the calling function.
+static void decode_url_escape_codes(gchar *str) {
   gchar *from = str;
   gchar *to = str;
 
@@ -58,8 +62,8 @@ GHashTable *g_uri_parse_params(const gchar *params, gssize lenght,
 
   for (GStrv p = param_list; *p != NULL; p++) {
     g_auto(GStrv) param = g_strsplit(*p, "=", 0);
-    parse_string(param[0]);
-    parse_string(param[1]);
+    decode_url_escape_codes(param[0]);
+    decode_url_escape_codes(param[1]);
     g_hash_table_insert(table, g_strdup(param[0]), g_strdup(param[1]));
   }
   return table;

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -50,7 +50,7 @@ static void decode_url_escape_codes(gchar *str) {
     value += HEX_CHAR_TO_NUMBER(*from);
     *to = value;
   }
-  *to = 0;
+  *to = 0; // ensure to zero-ending the string
 }
 
 GHashTable *g_uri_parse_params(const gchar *params, gssize lenght,

--- a/tests/mock-snapd.h
+++ b/tests/mock-snapd.h
@@ -43,6 +43,14 @@ typedef struct _MockTask MockTask;
 typedef struct _MockTrack MockTrack;
 typedef struct _MockNotice MockNotice;
 
+#if !GLIB_CHECK_VERSION(2, 66, 0)
+GHashTable *g_uri_parse_params(const gchar *params, gssize lenght,
+                               const gchar *separators, int flags,
+                               GError **error);
+
+#define G_URI_PARAMS_NONE 0
+#endif
+
 MockSnapd *mock_snapd_new(void);
 
 const gchar *mock_snapd_get_socket_path(MockSnapd *snapd);


### PR DESCRIPTION
The mock-snapd class allows to simulate receiving notices, but until now it didn't honor the "after" field, so it always returned all the notices.

This patch changes this, also allowing to test that the "after" parameter is correctly parsed. This, also, allowed to find a bug when requesting notices after a specific date when using GLib 2.65 or previous.