### PR TITLE
Fix warning

### DIFF
--- a/snapd-glib/snapd-notice.c
+++ b/snapd-glib/snapd-notice.c
@@ -103,7 +103,7 @@ const gchar *snapd_notice_get_user_id(SnapdNotice *self) {
  *
  * Since: 1.65
  */
-const SnapdNoticeType snapd_notice_get_notice_type(SnapdNotice *self) {
+SnapdNoticeType snapd_notice_get_notice_type(SnapdNotice *self) {
   g_return_val_if_fail(SNAPD_IS_NOTICE(self), SNAPD_NOTICE_TYPE_UNKNOWN);
   return self->type;
 }

--- a/snapd-glib/snapd-notice.h
+++ b/snapd-glib/snapd-notice.h
@@ -33,7 +33,7 @@ const gchar *snapd_notice_get_id(SnapdNotice *notice);
 
 const gchar *snapd_notice_get_user_id(SnapdNotice *notice);
 
-const SnapdNoticeType snapd_notice_get_notice_type(SnapdNotice *notice);
+SnapdNoticeType snapd_notice_get_notice_type(SnapdNotice *notice);
 
 const gchar *snapd_notice_get_key(SnapdNotice *notice);
 


### PR DESCRIPTION
The snapd_notice_get_notice_type() method returns a notice type, which is an `enum`. But the return type is defined as `const`, which causes a warning in the compiler when using the option `-Wignored-qualifiers`.

This patch removes the unneeded `const` qualifier to remove this warning.

Fix https://github.com/canonical/snapd-glib/issues/200