### PR TITLE
Update version number

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project ('snapd-glib', [ 'c', 'cpp' ],
-         version: '1.67',
+         version: '1.68',
          meson_version: '>= 0.58.0',
          default_options : [ 'c_std=c11' ])
 

--- a/snapd-glib/snapd-version.h
+++ b/snapd-glib/snapd-version.h
@@ -684,4 +684,14 @@
  */
 #define SNAPD_GLIB_VERSION_1_67
 
+/**
+ * SNAPD_GLIB_VERSION_1_68:
+ *
+ * A define that can be used by the C pre-processor to check for features
+ * in 1.68
+ *
+ * Since: 1.68
+ */
+#define SNAPD_GLIB_VERSION_1_68
+
 #endif /* __SNAPD_GLIB_VERSION_H__ */


### PR DESCRIPTION
After setting the 1.67 tag, it's required to update the version value to 1.68 in meson.build.