### PR TITLE
Install the globals file, otherwise we can't build the rest of headers

### DIFF
--- a/snapd-qt/meson.build
+++ b/snapd-qt/meson.build
@@ -113,6 +113,7 @@ source_h = [
   'Snapd/task-data.h',
   'Snapd/user-information.h',
   'Snapd/wrapped-object.h',
+  'Snapd/snapdqt_global.h',
 ]
 
 source_alias_h = [


### PR DESCRIPTION
Might have missed something, not super familiar with meson.