### PR TITLE
Update definitions to version 1.69

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project ('snapd-glib', [ 'c', 'cpp' ],
-         version: '1.68',
+         version: '1.69',
          meson_version: '>= 0.58.0',
          default_options : [ 'c_std=c11' ])
 

--- a/snapd-glib/snapd-version.h
+++ b/snapd-glib/snapd-version.h
@@ -694,4 +694,14 @@
  */
 #define SNAPD_GLIB_VERSION_1_68
 
+/**
+ * SNAPD_GLIB_VERSION_1_69:
+ *
+ * A define that can be used by the C pre-processor to check for features
+ * in 1.69
+ *
+ * Since: 1.69
+ */
+#define SNAPD_GLIB_VERSION_1_69
+
 #endif /* __SNAPD_GLIB_VERSION_H__ */


### PR DESCRIPTION
Since version 1.68 has been tagged, this PR changes all the version definitions to 1.69, to make the code ready for the next release.