### PR TITLE
Update definitions to version 1.70

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project ('snapd-glib', [ 'c', 'cpp' ],
-         version: '1.69',
+         version: '1.70',
          meson_version: '>= 0.58.0',
          default_options : [ 'c_std=c11' ])
 

--- a/snapd-glib/snapd-version.h
+++ b/snapd-glib/snapd-version.h
@@ -704,4 +704,14 @@
  */
 #define SNAPD_GLIB_VERSION_1_69
 
+/**
+ * SNAPD_GLIB_VERSION_1_70:
+ *
+ * A define that can be used by the C pre-processor to check for features
+ * in 1.70
+ *
+ * Since: 1.70
+ */
+#define SNAPD_GLIB_VERSION_1_70
+
 #endif /* __SNAPD_GLIB_VERSION_H__ */


### PR DESCRIPTION
Since version 1.69 has been tagged, this PR changes all the version definitions to 1.70, to make the code ready for the next release.