### PR TITLE
Fix build in ARCH

### DIFF
--- a/snapd-qt/Snapd/link.h
+++ b/snapd-qt/Snapd/link.h
@@ -13,7 +13,7 @@
 #include <QtCore/QObject>
 #include <Snapd/WrappedObject>
 
-class Q_DECL_EXPORT QSnapdLink : public QSnapdWrappedObject {
+class LIBSNAPDQT_EXPORT QSnapdLink : public QSnapdWrappedObject {
   Q_OBJECT
 
   Q_PROPERTY(QString type READ type)


### PR DESCRIPTION
It's not possible to use Q_DECL_EXPORT due to Arch compiling with no_direct_extern_access (https://github.com/canonical/snapd-glib/issues/175 ) so our own macro LIBSNAPDQT_EXPORT must be used.

This patch fixes it.