### PR TITLE
Ensure that Q_DECL_EXPORT is not used

### DIFF
--- a/.github/workflows/check_q_decl_export.yaml
+++ b/.github/workflows/check_q_decl_export.yaml
@@ -1,0 +1,22 @@
+name: Verify no Q_DECL_EXPORT is used
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Verify no Q_DECL_EXPORT is used
+        run: |
+          if grep Q_DECL_EXPORT snapd-qt/Snapd/*.h ; then
+            echo There are Q_DECL_EXPORT definitions in the Qt headers!!!
+            echo Replace them with LIBSNAPDQT_EXPORT
+            echo See https://github.com/canonical/snapd-glib/issues/175
+            exit 1
+          fi


### PR DESCRIPTION
As seen in https://github.com/canonical/snapd-glib/issues/175 , using Q_DECL_EXPORT can result in not being able to build in Arch.

This test ensures that no Q_DECL_EXPORT is used, and explains why and how to replace it with the right macro.