### PR TITLE
Update definitions to version 1.71

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project ('snapd-glib', [ 'c', 'cpp' ],
-         version: '1.70',
+         version: '1.71',
          meson_version: '>= 0.58.0',
          default_options : [ 'c_std=c11' ])
 

--- a/snapd-glib/snapd-version.h
+++ b/snapd-glib/snapd-version.h
@@ -714,4 +714,14 @@
  */
 #define SNAPD_GLIB_VERSION_1_70
 
+/**
+ * SNAPD_GLIB_VERSION_1_71:
+ *
+ * A define that can be used by the C pre-processor to check for features
+ * in 1.71
+ *
+ * Since: 1.71
+ */
+#define SNAPD_GLIB_VERSION_1_71
+
 #endif /* __SNAPD_GLIB_VERSION_H__ */


### PR DESCRIPTION
Since version 1.70 has been tagged, this PR changes all the version definitions to 1.71, to make the code ready for the next release.