### PR TITLE
ci: Allow to rename the default branch to `main`

### DIFF
--- a/.github/workflows/check_q_decl_export.yaml
+++ b/.github/workflows/check_q_decl_export.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - master
 
 jobs:

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -3,6 +3,7 @@ name: documentation
 on:
   push:
     branches:
+      - main
       - master
 
 permissions:

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - master
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - master
 
 jobs:


### PR DESCRIPTION
Currently, the default branch is `master`, but we are renaming all of them to the current default name `main`. Unfortunately, the CI tests expects the default branch to be `master`.

This patch changes this to support both branches, thus allowing the renaming at any moment.