### PR TITLE
snapd-qt: Change soup3-based QML module name to Snapd2

### DIFF
--- a/snapd-qt/meson.build
+++ b/snapd-qt/meson.build
@@ -185,9 +185,6 @@ pc.generate (libraries: snapd_qt_lib,
               version: meson.project_version (),
               requires: pc_required_qt,)
 
-install_data ('qmldir',
-              install_dir: qml_dir)
-
 cmake_conf = configuration_data ()
 cmake_conf.set ('libdir', libdir)
 cmake_conf.set ('includedir', includedir)
@@ -203,7 +200,18 @@ install_data (cmake_file, cmake_version_file,
               install_dir: cmake_dir)
 
   if get_option ('qml-bindings')
-    install_data ('qmldir',
+    qml_cppflags = []
+    if not get_option('soup2')
+        qml_cppflags += [ '-DSNAPD_QML_SNAPD2' ]
+    endif
+
+    qmldir_conf = configuration_data ()
+    qmldir_conf.set ('module_name', qt_name)
+    qmldir_conf.set ('plugin_name', qt_name)
+    qmldir_file = configure_file (input: 'qmldir.in',
+                                   output: 'qmldir',
+                                   configuration: qmldir_conf)
+    install_data (qmldir_file,
                   install_dir: qml_dir)
 
     qml_moc_files = qt.preprocess (moc_headers: 'qml-plugin.h',
@@ -211,6 +219,7 @@ install_data (cmake_file, cmake_version_file,
     library (qt_name,
               'qml-plugin.cpp', qml_moc_files,
               dependencies: [ qml_dep, snapd_qt_dep ],
+              cpp_args: qml_cppflags,
               build_rpath: qml_dir,
               install: true,
               install_dir: qml_dir)

--- a/snapd-qt/qml-plugin.cpp
+++ b/snapd-qt/qml-plugin.cpp
@@ -12,7 +12,12 @@
 #include <Snapd/Client>
 
 void SnapdQmlPlugin::registerTypes(const char *uri) {
+#ifndef SNAPD_QML_SNAPD2
   Q_ASSERT(uri == QLatin1String("Snapd"));
+#else
+  Q_ASSERT(uri == QLatin1String("Snapd2"));
+#endif
+
   qmlRegisterType<QSnapdClient>(uri, 1, 0, "SnapdClient");
   qmlRegisterType<QSnapdAuthData>(uri, 1, 0, "SnapdAuthData");
   qmlRegisterUncreatableType<QSnapdIcon>(uri, 1, 0, "SnapdIcon",

--- a/snapd-qt/qmldir
+++ b/snapd-qt/qmldir
@@ -1,2 +1,0 @@
-module Snapd
-plugin Snapd

--- a/snapd-qt/qmldir.in
+++ b/snapd-qt/qmldir.in
@@ -1,0 +1,2 @@
+module @module_name@
+plugin @plugin_name@


### PR DESCRIPTION
Force QML binding consumers to select either `Snapd` or `Snapd2` as the module import for libsoup2 and libsoup3 not to clash in the same process.

For libsoup2 builds require: `import Snapd 1.0`
For libsoup3 builds require: `import Snapd2 1.0`

Fixes: https://github.com/canonical/snapd-glib/issues/216